### PR TITLE
chore: strip historical phases from ARCHITECTURE.md, add ROADMAP.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -268,50 +268,6 @@ Dutch Defense, English Opening.
 
 ---
 
-## Task Breakdown
-
-### Phase 1 — Setup (Day 1)
-- [x] `cargo new fetcher` — init Rust project
-- [x] Add `reqwest`, `tokio`, `serde`, `serde_json`, `clap` to `Cargo.toml`
-- [x] Populate `openings.json` with 20 ECO codes and their move-8 FENs
-- [x] Create `data/raw/`, `data/processed/`, `data/output/` directories
-
-### Phase 2 — Rust Fetcher (Day 2–3)
-- [x] Write `models.rs`: serde structs matching Lichess Explorer API response
-- [x] Write `client.rs`: async GET with query params + 1s rate limit sleep
-- [x] Write `main.rs`: loop openings × months, write JSON to `data/raw/`
-- [x] Test against one opening (Sicilian, B20) before full batch run
-- [x] Full batch run: 20 openings × 39 months (2023-01 → 2026-03) = 780 JSON files
-
-### Phase 3 — Ingestion (Day 4)
-- [x] Write `ingest.py`: JSON → `openings_ts.csv` with schema above
-- [x] Filter low-confidence months (`total < 500`)
-- [x] Sanity-check: win rates confirmed in 0.46–0.51 range across all 20 openings
-
-### Phase 4 — ARIMA (Day 5–6)
-- [x] Write `timeseries.py`: ADF → auto_arima → forecast → break detection
-- [x] Validate residuals with Ljung-Box test for each fitted model (all 20 pass)
-- [x] Write `forecasts.csv` (840 rows: 780 actual + 60 forecast)
-
-### Phase 5 — Engine Delta (Day 7)
-- [x] Install Stockfish 16 binary (`/usr/games/stockfish`), configure path
-- [x] Write `engine_delta.py`: replay UCI moves via python-chess → get FEN → Stockfish depth-20 eval
-- [x] Compute sigmoid probability and delta, write `engine_delta.csv` (20 rows)
-- **Results:** 8 openings engine-favoured (delta < −0.04) — D70 Grünfeld (−0.0644), B01 Scandinavian (−0.0581), B07 Pirc (−0.0558), B06 Modern (−0.0526), E60 King's Indian (−0.0501), C20 King's Gambit (−0.0465), C00 French (−0.0423), B20 Sicilian (−0.0447). No opening shows humans outperforming engine at 2000-rated blitz.
-
-### Phase 6 — Visualization (Day 8)
-- [x] Write `visualizer.py`: 3-panel Plotly dashboard as `dashboard.html` (31KB, CDN-hosted JS)
-- [x] Panel 1: Forecast line chart + shaded 95% CI for top-5 openings (B20, C44, C00, B12, A10), structural breaks as dotted vertical lines
-- [x] Panel 2: Bubble chart — engine cp vs human win rate, diagonal reference, bubble size = total volume
-- [x] Panel 3: ECO-category × month heatmap, diverging red-white-green at 0.50
-- [x] `main.py` orchestrator with stage flags already in place
-
-### Phase 7 — Documentation (Day 9)
-- [x] `README.md`: hypothesis + engine-delta findings table + structural break narrative per opening
-- [x] All phases documented with actual metrics in ARCHITECTURE.md
-
----
-
 ## Dependencies
 
 ### Rust (`Cargo.toml`)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,29 @@
+# OpenCast — Roadmap
+
+This file tracks planned work. ARCHITECTURE.md is the stable design
+reference; this file is the versioned plan.
+
+***
+
+## Phase A — Opening Universe & Selection
+- Introduce `openings_catalog.csv` as the canonical opening list
+- Make the Rust fetcher and Python pipeline drive from the catalogue
+- Define data-driven selection criteria for "core tracked" openings
+- Generate aggregated stats for long-tail openings
+
+## Phase B — Scalable Modeling Tiers
+- Assign model tiers (1/2/3) per opening based on volume and stability
+- Tier 1: current ARIMA + Chow + engine delta (core openings only)
+- Tier 2: lighter models (Holt-Winters or rolling trend), no break tests
+- Tier 3: descriptive stats only
+- Add CI timing guardrails to prevent runaway runtimes
+
+## Phase C — Modular Dashboard
+- Replace single dashboard.html with a multi-page static site structure
+- Pages: overview (index.html), openings table, per-opening detail, families
+- Surface findings.json insights as headline widgets on the overview page
+- Link structure between all pages with a shared navigation bar
+
+## Phase D — Architecture Docs Cleanup
+- Strip historical Phase 1–7 task breakdown from ARCHITECTURE.md
+- Add this ROADMAP.md


### PR DESCRIPTION
## Summary

Cleans up ARCHITECTURE.md by removing the historical Phase 1–7 task breakdown (now completed artefacts) and introduces a forward-looking ROADMAP.md.

## Changes

### `ARCHITECTURE.md`
- Removed the entire `## Task Breakdown` section (Phase 1 through Phase 7 with all sub-bullets, checkboxes, and inline results)
- All six stable sections preserved exactly as-is: Project Goal, Data Flow, File Structure, Module Specifications, Dependencies, Known Constraints

### `ROADMAP.md` (new file)
- Created at repo root
- Documents planned Phases A–D (Opening Universe, Modeling Tiers, Modular Dashboard, Architecture Docs Cleanup)
- Serves as the versioned plan going forward; ARCHITECTURE.md remains the stable design reference

## Notes
- No code changes — documentation only
- This is Phase D in the planned roadmap
