### PR TITLE
feat: opening universe catalogue, selection criteria, model tier routing

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
-      # ── Rust toolchain & fetcher ──────────────────────────────────────────
+      # ── Rust toolchain & fetcher ─────────────────────────────────────────────────────
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
@@ -39,7 +39,7 @@ jobs:
         run: cargo build --release
         working-directory: fetcher
 
-      # ── Fetch missing months ──────────────────────────────────────────────
+      # ── Fetch missing months ─────────────────────────────────────────────────────────
       - name: Fetch missing months (incremental)
         id: fetch_step
         env:
@@ -128,7 +128,7 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
-      # ── Python environment ────────────────────────────────────────────────
+      # ── Python environment ──────────────────────────────────────────────────────────────
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -140,14 +140,14 @@ jobs:
       - name: Install Python dependencies
         run: uv pip install --system -r requirements.txt
 
-      # ── Stockfish ────────────────────────────────────────────────────────
+      # ── Stockfish ────────────────────────────────────────────────────────────────────
       - name: Install Stockfish
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y stockfish
 
-      # ── Pipeline ─────────────────────────────────────────────────────────
-      - name: Run ingest → timeseries → engine delta
+      # ── Pipeline ─────────────────────────────────────────────────────────────────────
+      - name: Run ingest → select → timeseries → engine delta
         run: |
           rm -f data/processed/openings_ts.csv \
                 data/output/forecasts.csv \
@@ -155,9 +155,11 @@ jobs:
                 data/output/dashboard.html
           python -c "
           from src.ingest import ingest
+          from src.select_openings import run_select_openings
           from src.timeseries import run_timeseries
           from src.engine_delta import run_engine_delta
           ingest()
+          run_select_openings()
           run_timeseries()
           run_engine_delta()
           "
@@ -168,7 +170,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/processed/openings_ts.csv \
                   data/output/forecasts.csv \
-                  data/output/engine_delta.csv
+                  data/output/engine_delta.csv \
+                  data/openings_catalog.csv \
+                  data/output/long_tail_stats.csv
           git diff --cached --quiet || git commit -m "chore: auto-update $(date +%Y-%m)"
           git push
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,13 +57,16 @@ opencast/
 │   ├── raw/                   ← JSON files from Rust fetcher (one per opening/month)
 │   ├── processed/
 │   │   └── openings_ts.csv    ← (month, eco, opening_name, rating, white, draws, black, total)
+│   ├── openings_catalog.csv   ← canonical opening catalogue with tier flags
 │   └── output/
 │       ├── forecasts.csv      ← ARIMA forecasts with confidence intervals
-│       └── engine_delta.csv   ← centipawn vs human win rate delta per opening
+│       ├── engine_delta.csv   ← centipawn vs human win rate delta per opening
+│       └── long_tail_stats.csv ← descriptive stats for long-tail openings
 │
 ├── src/
 │   ├── __init__.py
 │   ├── ingest.py              ← reads data/raw/ JSONs → openings_ts.csv
+│   ├── select_openings.py     ← computes selection flags and model tiers
 │   ├── timeseries.py          ← ARIMA fitting, forecasting, structural break detection
 │   ├── engine_delta.py        ← Stockfish eval → delta computation
 │   └── visualizer.py          ← Plotly 3-panel dashboard (exports .html)
@@ -116,6 +119,7 @@ with `?`, struct-based deserialization, file I/O with `std::fs`.
 ```
 INPUT  : data/raw/*.json
 OUTPUT : data/processed/openings_ts.csv
+         data/output/long_tail_stats.csv
 ```
 
 **Output schema:**
@@ -128,6 +132,28 @@ month | eco | opening_name | rating_bracket | white | draws | black | total | wh
 - Compute `white_win_rate = white / (white + draws + black)`
 - Drop rows where `total < 500` — statistically unreliable months
 - Flag months where `total < 2000` with a `low_confidence` boolean column
+- After writing `openings_ts.csv`, compute long-tail stats from catalog and write `long_tail_stats.csv`
+
+---
+
+### `src/select_openings.py` — Python
+
+**Responsibility:** Compute per-ECO selection flags and model tiers from time series
+data and merge them into `data/openings_catalog.csv`.
+
+**Interface:**
+```
+INPUT  : data/processed/openings_ts.csv
+         data/openings_catalog.csv
+OUTPUT : data/openings_catalog.csv (updated in-place)
+```
+
+**Selection rules:**
+- `is_tracked_core = True` if `avg_monthly_games ≥ 1000` AND `months_with_data ≥ 24`
+- `is_long_tail = True` if `avg_monthly_games ≥ 100` AND NOT `is_tracked_core`
+- `model_tier = 1` if `is_tracked_core`
+- `model_tier = 2` if `is_long_tail` AND `avg_monthly_games ≥ 500`
+- `model_tier = 3` if `is_long_tail` AND `avg_monthly_games < 500`
 
 ---
 
@@ -139,6 +165,7 @@ month | eco | opening_name | rating_bracket | white | draws | black | total | wh
 **Interface:**
 ```
 INPUT  : data/processed/openings_ts.csv
+         data/openings_catalog.csv
 OUTPUT : data/output/forecasts.csv
 ```
 
@@ -154,6 +181,8 @@ eco | opening_name | month | actual | forecast | lower_ci | upper_ci | is_foreca
 4. Forecast 3 months ahead with 95% confidence intervals
 5. Structural break detection via `statsmodels` Chow test at each month
 6. Ljung-Box test on residuals — log warning if autocorrelation remains
+
+**Tier filtering:** Only processes ECOs with `model_tier == 1` (Tier 2/3 added in Phase B).
 
 **Libraries:** `pmdarima`, `statsmodels`, `pandas`, `numpy`
 
@@ -172,6 +201,7 @@ actual human win rates.
 ```
 INPUT  : openings.json (ECO → FEN after move 8)
          data/processed/openings_ts.csv (for human win rates at 2000+ bracket)
+         data/openings_catalog.csv
 OUTPUT : data/output/engine_delta.csv
 ```
 
@@ -179,6 +209,8 @@ OUTPUT : data/output/engine_delta.csv
 ```
 eco | opening_name | engine_cp | p_engine | human_win_rate_2000 | delta | interpretation
 ```
+
+**Tier filtering:** Only evaluates ECOs with `model_tier == 1`.
 
 **Centipawn → probability conversion:**
 
@@ -239,6 +271,7 @@ already exists (avoid re-fetching).
 STAGES = {
     "fetch"   : True,   # set False after first run
     "ingest"  : True,
+    "select"  : True,
     "ts"      : True,
     "engine"  : True,
     "viz"     : True,
@@ -265,50 +298,6 @@ Covers 20 openings across ECO categories A–E, including:
 Sicilian Defense, London System, King's Indian Defense, Caro-Kann,
 Queen's Gambit Declined, Ruy Lopez, French Defense, King's Gambit,
 Dutch Defense, English Opening.
-
----
-
-## Task Breakdown
-
-### Phase 1 — Setup (Day 1)
-- [x] `cargo new fetcher` — init Rust project
-- [x] Add `reqwest`, `tokio`, `serde`, `serde_json`, `clap` to `Cargo.toml`
-- [x] Populate `openings.json` with 20 ECO codes and their move-8 FENs
-- [x] Create `data/raw/`, `data/processed/`, `data/output/` directories
-
-### Phase 2 — Rust Fetcher (Day 2–3)
-- [x] Write `models.rs`: serde structs matching Lichess Explorer API response
-- [x] Write `client.rs`: async GET with query params + 1s rate limit sleep
-- [x] Write `main.rs`: loop openings × months, write JSON to `data/raw/`
-- [x] Test against one opening (Sicilian, B20) before full batch run
-- [x] Full batch run: 20 openings × 39 months (2023-01 → 2026-03) = 780 JSON files
-
-### Phase 3 — Ingestion (Day 4)
-- [x] Write `ingest.py`: JSON → `openings_ts.csv` with schema above
-- [x] Filter low-confidence months (`total < 500`)
-- [x] Sanity-check: win rates confirmed in 0.46–0.51 range across all 20 openings
-
-### Phase 4 — ARIMA (Day 5–6)
-- [x] Write `timeseries.py`: ADF → auto_arima → forecast → break detection
-- [x] Validate residuals with Ljung-Box test for each fitted model (all 20 pass)
-- [x] Write `forecasts.csv` (840 rows: 780 actual + 60 forecast)
-
-### Phase 5 — Engine Delta (Day 7)
-- [x] Install Stockfish 16 binary (`/usr/games/stockfish`), configure path
-- [x] Write `engine_delta.py`: replay UCI moves via python-chess → get FEN → Stockfish depth-20 eval
-- [x] Compute sigmoid probability and delta, write `engine_delta.csv` (20 rows)
-- **Results:** 8 openings engine-favoured (delta < −0.04) — D70 Grünfeld (−0.0644), B01 Scandinavian (−0.0581), B07 Pirc (−0.0558), B06 Modern (−0.0526), E60 King's Indian (−0.0501), C20 King's Gambit (−0.0465), C00 French (−0.0423), B20 Sicilian (−0.0447). No opening shows humans outperforming engine at 2000-rated blitz.
-
-### Phase 6 — Visualization (Day 8)
-- [x] Write `visualizer.py`: 3-panel Plotly dashboard as `dashboard.html` (31KB, CDN-hosted JS)
-- [x] Panel 1: Forecast line chart + shaded 95% CI for top-5 openings (B20, C44, C00, B12, A10), structural breaks as dotted vertical lines
-- [x] Panel 2: Bubble chart — engine cp vs human win rate, diagonal reference, bubble size = total volume
-- [x] Panel 3: ECO-category × month heatmap, diverging red-white-green at 0.50
-- [x] `main.py` orchestrator with stage flags already in place
-
-### Phase 7 — Documentation (Day 9)
-- [x] `README.md`: hypothesis + engine-delta findings table + structural break narrative per opening
-- [x] All phases documented with actual metrics in ARCHITECTURE.md
 
 ---
 
@@ -346,3 +335,4 @@ requests
 | ARIMA requires ≥ 24 data points per opening | Fetch from 2023-01 → 2026-03 (27 months) |
 | Stockfish must be installed locally | Document path config in README |
 | Opening Explorer FENs must match mainline exactly | Validate FENs in openings.json against Lichess Explorer UI |
+| Opening catalogue coverage | openings_catalog.csv drives all pipeline stages; openings absent from it are silently ignored |

--- a/data/openings_catalog.csv
+++ b/data/openings_catalog.csv
@@ -1,0 +1,21 @@
+eco,name,eco_group,moves,is_tracked_core,is_long_tail,model_tier
+B20,Sicilian Defense,B,"e2e4,c7c5",True,False,1
+B12,Caro-Kann Defense,B,"e2e4,c7c6",True,False,1
+C00,French Defense,C,"e2e4,e7e6",True,False,1
+B01,Scandinavian Defense,B,"e2e4,d7d5",True,False,1
+C44,King's Pawn Game,C,"e2e4,e7e5",True,False,1
+C50,Italian Game,C,"e2e4,e7e5,g1f3,b8c6,f1c4",True,False,1
+C60,Ruy Lopez,C,"e2e4,e7e5,g1f3,b8c6,f1b5",True,False,1
+C20,King's Gambit,C,"e2e4,e7e5,f2f4",True,False,1
+D00,London System,D,"d2d4,d7d5,g1f3,g8f6,c1f4",True,False,1
+D06,Queen's Gambit,D,"d2d4,d7d5,c2c4",True,False,1
+D30,Queen's Gambit Declined,D,"d2d4,d7d5,c2c4,e7e6",True,False,1
+D70,Grunfeld Defense,D,"d2d4,g8f6,c2c4,g7g6,b1c3,d7d5",True,False,1
+E60,King's Indian Defense,E,"d2d4,g8f6,c2c4,g7g6,b1c3,f8g7",True,False,1
+E20,Nimzo-Indian Defense,E,"d2d4,g8f6,c2c4,e7e6,b1c3,f8b4",True,False,1
+A10,English Opening,A,c2c4,True,False,1
+A45,Trompowsky Attack,A,"d2d4,g8f6,c1g5",True,False,1
+B06,Modern Defense,B,"e2e4,g7g6",True,False,1
+A00,Polish Opening,A,b2b4,True,False,1
+C41,Philidor Defense,C,"e2e4,e7e5,g1f3,d7d6",True,False,1
+B07,Pirc Defense,B,"e2e4,d7d6,d2d4,g8f6",True,False,1

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ except Exception:  # pragma: no cover
 STAGES = {
     "fetch"  : False,  # set True to re-fetch from Lichess
     "ingest" : True,
+    "select" : True,
     "ts"     : True,
     "engine" : True,
     "viz"    : True,
@@ -20,6 +21,7 @@ STAGES = {
 }
 
 PROCESSED_CSV  = "data/processed/openings_ts.csv"
+CATALOG_CSV    = "data/openings_catalog.csv"
 FORECASTS_CSV  = "data/output/forecasts.csv"
 ENGINE_CSV     = "data/output/engine_delta.csv"
 DASHBOARD_HTML = "data/output/dashboard.html"
@@ -203,6 +205,11 @@ def main():
         print("--- Stage: ingest ---")
         from src.ingest import ingest
         ingest()
+
+    if STAGES["select"] and not _skip_or_force(CATALOG_CSV, "select", force_recompute):
+        print("--- Stage: select ---")
+        from src.select_openings import run_select_openings
+        run_select_openings()
 
     if STAGES["ts"] and not _skip_or_force(FORECASTS_CSV, "timeseries", force_recompute):
         print("--- Stage: timeseries ---")

--- a/src/engine_delta.py
+++ b/src/engine_delta.py
@@ -10,6 +10,7 @@ from stockfish import Stockfish
 _HERE = os.path.dirname(__file__)
 OPENINGS_JSON = os.path.join(_HERE, "..", "openings.json")
 PROCESSED_CSV = os.path.join(_HERE, "..", "data", "processed", "openings_ts.csv")
+CATALOG_CSV   = os.path.join(_HERE, "..", "data", "openings_catalog.csv")
 OUTPUT_CSV    = os.path.join(_HERE, "..", "data", "output", "engine_delta.csv")
 OUTPUT_DIR    = os.path.join(_HERE, "..", "data", "output")
 
@@ -44,7 +45,15 @@ def _interpret(delta: float) -> str:
 
 def run_engine_delta() -> pd.DataFrame:
     with open(OPENINGS_JSON) as f:
-        openings = json.load(f)
+        all_openings = json.load(f)
+
+    # Filter to Tier-1 openings only
+    catalog = pd.read_csv(CATALOG_CSV)
+    tier1_ecos = set(catalog.loc[catalog["model_tier"] == 1, "eco"])
+    openings = [o for o in all_openings if o["eco"] in tier1_ecos]
+    import logging
+    log = logging.getLogger(__name__)
+    log.info("Engine delta: evaluating %d Tier-1 ECOs", len(openings))
 
     ts = pd.read_csv(PROCESSED_CSV)
     human_rates = (
@@ -96,14 +105,14 @@ def run_engine_delta() -> pd.DataFrame:
 
     df = pd.DataFrame(rows)
     df.to_csv(OUTPUT_CSV, index=False)
-    print(f"\nEngine delta written → {OUTPUT_CSV}  ({len(df)} rows)")
+    print(f"\nEngine delta written \u2192 {OUTPUT_CSV}  ({len(df)} rows)")
     return df
 
 
 def recommend_openings(delta_df: pd.DataFrame | None = None) -> pd.DataFrame:
     """Return openings ranked by delta (highest = most human-favourable).
 
-    A positive delta means humans outperform the engine prediction — these are
+    A positive delta means humans outperform the engine prediction \u2014 these are
     the best openings to play at 2000-rated blitz relative to engine expectation.
     """
     if delta_df is None:

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -2,13 +2,16 @@ import json
 import os
 import re
 
+import numpy as np
 import pandas as pd
 
 _HERE = os.path.dirname(__file__)
 RAW_DIR = os.path.join(_HERE, "..", "data", "raw")
 PROCESSED_DIR = os.path.join(_HERE, "..", "data", "processed")
 OPENINGS_JSON = os.path.join(_HERE, "..", "openings.json")
-OUTPUT_CSV = os.path.join(PROCESSED_DIR, "openings_ts.csv")
+CATALOG_CSV   = os.path.join(_HERE, "..", "data", "openings_catalog.csv")
+OUTPUT_CSV    = os.path.join(PROCESSED_DIR, "openings_ts.csv")
+LONG_TAIL_CSV = os.path.join(_HERE, "..", "data", "output", "long_tail_stats.csv")
 
 RATING_BRACKET = 2000
 MIN_GAMES = 500
@@ -21,6 +24,59 @@ def _load_name_map() -> dict:
     with open(OPENINGS_JSON) as f:
         openings = json.load(f)
     return {o["eco"]: o["name"] for o in openings}
+
+
+def _compute_long_tail_stats(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute descriptive stats for long-tail openings from catalog."""
+    if not os.path.exists(CATALOG_CSV):
+        return pd.DataFrame(columns=["eco", "name", "last_year_win_rate",
+                                     "total_games_last_year", "trend_direction"])
+
+    catalog = pd.read_csv(CATALOG_CSV)
+    long_tail_ecos = set(
+        catalog.loc[catalog["is_long_tail"] == True, "eco"]
+    )
+
+    if not long_tail_ecos:
+        return pd.DataFrame(columns=["eco", "name", "last_year_win_rate",
+                                     "total_games_last_year", "trend_direction"])
+
+    name_map = catalog.set_index("eco")["name"].to_dict()
+
+    rows = []
+    for eco in long_tail_ecos:
+        grp = df[df["eco"] == eco].sort_values("month")
+        if grp.empty:
+            continue
+
+        last12 = grp.tail(12)
+        last_year_win_rate    = float(last12["white_win_rate"].mean())
+        total_games_last_year = int(last12["total"].sum())
+
+        # Slope for trend direction
+        y = last12["white_win_rate"].values.astype(float)
+        if len(y) >= 2:
+            x = np.arange(len(y), dtype=float)
+            slope = float(np.polyfit(x, y, 1)[0])
+        else:
+            slope = 0.0
+
+        if slope > 0.001:
+            trend_direction = "rising"
+        elif slope < -0.001:
+            trend_direction = "falling"
+        else:
+            trend_direction = "stable"
+
+        rows.append({
+            "eco":                  eco,
+            "name":                 name_map.get(eco, eco),
+            "last_year_win_rate":   round(last_year_win_rate, 6),
+            "total_games_last_year": total_games_last_year,
+            "trend_direction":      trend_direction,
+        })
+
+    return pd.DataFrame(rows)
 
 
 def ingest() -> pd.DataFrame:
@@ -60,7 +116,14 @@ def ingest() -> pd.DataFrame:
 
     df = pd.DataFrame(rows)
     df.to_csv(OUTPUT_CSV, index=False)
-    print(f"Ingested {len(df)} rows → {OUTPUT_CSV}")
+    print(f"Ingested {len(df)} rows \u2192 {OUTPUT_CSV}")
+
+    # Write long-tail stats
+    os.makedirs(os.path.dirname(LONG_TAIL_CSV), exist_ok=True)
+    long_tail_df = _compute_long_tail_stats(df)
+    long_tail_df.to_csv(LONG_TAIL_CSV, index=False)
+    print(f"Long-tail stats written \u2192 {LONG_TAIL_CSV}  ({len(long_tail_df)} rows)")
+
     return df
 
 

--- a/src/select_openings.py
+++ b/src/select_openings.py
@@ -1,0 +1,139 @@
+"""Compute opening selection flags and model tiers from openings_ts.csv.
+
+Reads data/processed/openings_ts.csv, computes per-ECO statistics, applies
+selection rules, and merges results into data/openings_catalog.csv.
+"""
+
+import logging
+import os
+
+import numpy as np
+import pandas as pd
+
+_HERE = os.path.dirname(__file__)
+PROCESSED_CSV = os.path.join(_HERE, "..", "data", "processed", "openings_ts.csv")
+CATALOG_CSV   = os.path.join(_HERE, "..", "data", "openings_catalog.csv")
+
+MIN_GAMES_CORE     = 1000
+MIN_MONTHS_CORE    = 24
+MIN_GAMES_LONGTAIL = 100
+MIN_GAMES_TIER2    = 500
+
+log = logging.getLogger(__name__)
+
+
+def _compute_eco_stats(ts: pd.DataFrame) -> pd.DataFrame:
+    """Compute per-ECO aggregate statistics from the time series dataframe."""
+    rows = []
+    for eco, grp in ts.groupby("eco"):
+        grp = grp.sort_values("month").reset_index(drop=True)
+
+        avg_monthly_games  = float(grp["total"].mean())
+        months_with_data   = int((grp["total"] >= 500).sum())
+
+        # Linear regression slope of white_win_rate over time (index as x)
+        y = grp["white_win_rate"].values.astype(float)
+        if len(y) >= 2:
+            x = np.arange(len(y), dtype=float)
+            win_rate_slope = float(np.polyfit(x, y, 1)[0])
+        else:
+            win_rate_slope = 0.0
+
+        rows.append({
+            "eco": eco,
+            "avg_monthly_games": avg_monthly_games,
+            "months_with_data":  months_with_data,
+            "win_rate_slope":    win_rate_slope,
+        })
+    return pd.DataFrame(rows)
+
+
+def _apply_selection_rules(stats: pd.DataFrame) -> pd.DataFrame:
+    """Apply is_tracked_core, is_long_tail, and model_tier flags to stats."""
+    stats = stats.copy()
+
+    stats["is_tracked_core"] = (
+        (stats["avg_monthly_games"] >= MIN_GAMES_CORE) &
+        (stats["months_with_data"]  >= MIN_MONTHS_CORE)
+    )
+    stats["is_long_tail"] = (
+        (stats["avg_monthly_games"] >= MIN_GAMES_LONGTAIL) &
+        (~stats["is_tracked_core"])
+    )
+
+    def _tier(row: pd.Series) -> int:
+        if row["is_tracked_core"]:
+            return 1
+        if row["is_long_tail"] and row["avg_monthly_games"] >= MIN_GAMES_TIER2:
+            return 2
+        if row["is_long_tail"]:
+            return 3
+        return 3  # everything else gets Tier 3 by default
+
+    stats["model_tier"] = stats.apply(_tier, axis=1)
+    return stats
+
+
+def run_select_openings() -> pd.DataFrame:
+    """Compute selection flags and merge into openings_catalog.csv.
+
+    Returns the updated catalog DataFrame.
+    """
+    ts = pd.read_csv(PROCESSED_CSV)
+    log.info("select_openings: loaded %d rows from %s", len(ts), PROCESSED_CSV)
+
+    stats = _compute_eco_stats(ts)
+    stats = _apply_selection_rules(stats)
+
+    log.info(
+        "select_openings: %d core, %d long-tail, %d other ECOs computed",
+        int(stats["is_tracked_core"].sum()),
+        int(stats["is_long_tail"].sum()),
+        int((~stats["is_tracked_core"] & ~stats["is_long_tail"]).sum()),
+    )
+
+    # Load existing catalog
+    catalog = pd.read_csv(CATALOG_CSV)
+
+    # For existing catalog rows, update the computed flag columns
+    stat_cols = ["is_tracked_core", "is_long_tail", "model_tier"]
+    stats_indexed = stats.set_index("eco")
+
+    for col in stat_cols:
+        catalog[col] = catalog["eco"].map(
+            lambda eco, c=col: stats_indexed.at[eco, c]
+            if eco in stats_indexed.index
+            else catalog.loc[catalog["eco"] == eco, c].values[0]
+        )
+
+    # Append new ECOs found in ts but not yet in catalog
+    known_ecos = set(catalog["eco"])
+    new_rows = []
+    for _, stat_row in stats.iterrows():
+        eco = stat_row["eco"]
+        if eco in known_ecos:
+            continue
+        # For newly discovered ECOs we don't have a name or moves — leave blank
+        # for a human to fill in; flags are computed from data.
+        new_rows.append({
+            "eco":             eco,
+            "name":            "",
+            "eco_group":       eco[0],
+            "moves":           "",
+            "is_tracked_core": bool(stat_row["is_tracked_core"]),
+            "is_long_tail":    bool(stat_row["is_long_tail"]),
+            "model_tier":      int(stat_row["model_tier"]),
+        })
+
+    if new_rows:
+        log.info("select_openings: appending %d new ECOs to catalog", len(new_rows))
+        catalog = pd.concat([catalog, pd.DataFrame(new_rows)], ignore_index=True)
+
+    catalog.to_csv(CATALOG_CSV, index=False)
+    log.info("select_openings: catalog updated → %s  (%d rows)", CATALOG_CSV, len(catalog))
+    return catalog
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    run_select_openings()

--- a/src/timeseries.py
+++ b/src/timeseries.py
@@ -15,7 +15,8 @@ warnings.filterwarnings("ignore")
 
 _HERE = os.path.dirname(__file__)
 PROCESSED_CSV = os.path.join(_HERE, "..", "data", "processed", "openings_ts.csv")
-OUTPUT_CSV = os.path.join(_HERE, "..", "data", "output", "forecasts.csv")
+CATALOG_CSV   = os.path.join(_HERE, "..", "data", "openings_catalog.csv")
+OUTPUT_CSV    = os.path.join(_HERE, "..", "data", "output", "forecasts.csv")
 
 MIN_POINTS = 24
 FORECAST_STEPS = 3
@@ -46,7 +47,7 @@ def _chow_test(y: np.ndarray, bp: int) -> tuple:
         return 0.0, 1.0
 
     rss_before = sm.OLS(y[:bp], sm.add_constant(t[:bp])).fit().ssr
-    rss_after = sm.OLS(y[bp:], sm.add_constant(t[bp:])).fit().ssr
+    rss_after  = sm.OLS(y[bp:], sm.add_constant(t[bp:])).fit().ssr
 
     k = 2  # intercept + slope
     denom = rss_before + rss_after
@@ -74,6 +75,12 @@ def run_timeseries(df: pd.DataFrame | None = None) -> pd.DataFrame:
     else:
         df = df.copy()
 
+    # Filter to Tier-1 openings only
+    catalog = pd.read_csv(CATALOG_CSV)
+    tier1_ecos = set(catalog.loc[catalog["model_tier"] == 1, "eco"])
+    df = df[df["eco"].isin(tier1_ecos)]
+    log.info("Timeseries: processing %d Tier-1 ECOs", len(tier1_ecos))
+
     df["month"] = pd.to_datetime(df["month"])
     os.makedirs(os.path.dirname(OUTPUT_CSV), exist_ok=True)
 
@@ -85,7 +92,7 @@ def run_timeseries(df: pd.DataFrame | None = None) -> pd.DataFrame:
         n = len(grp)
 
         if n < MIN_POINTS:
-            log.warning("%s: only %d data points, need ≥ %d — skipping", eco, n, MIN_POINTS)
+            log.warning("%s: only %d data points, need \u2265 %d \u2014 skipping", eco, n, MIN_POINTS)
             continue
 
         y = np.asarray(grp["white_win_rate"].values, dtype=float)
@@ -154,7 +161,7 @@ def run_timeseries(df: pd.DataFrame | None = None) -> pd.DataFrame:
 
     out = pd.DataFrame(records, columns=OUTPUT_COLUMNS)
     out.to_csv(OUTPUT_CSV, index=False)
-    print(f"Forecasts written → {OUTPUT_CSV}  ({len(out)} rows)")
+    print(f"Forecasts written \u2192 {OUTPUT_CSV}  ({len(out)} rows)")
     return out
 
 


### PR DESCRIPTION
## Summary

Introduces `openings_catalog.csv` as the canonical opening registry and wires it through the entire Python pipeline. Adds data-driven selection criteria to assign each opening an `is_tracked_core` / `is_long_tail` flag and a `model_tier` (1/2/3). Downstream stages (timeseries, engine delta) now route work only through Tier-1 openings.

> **Note:** This branch was cut from `develop`. It should be rebased once PR #7 (chore: strip historical phases) is merged.

## Changes

### New files
- **`data/openings_catalog.csv`** — 20-row catalogue seeded from `openings.json`; `eco_group`, `is_tracked_core=True`, `is_long_tail=False`, `model_tier=1` for all initial rows
- **`src/select_openings.py`** — `run_select_openings()` computes per-ECO stats (avg_monthly_games, months_with_data, win_rate_slope) from `openings_ts.csv`, applies selection rules, and merges flags back into the catalog; appends newly discovered ECOs

### Modified files
- **`main.py`** — Added `CATALOG_CSV` constant; added `"select": True` stage between `"ingest"` and `"ts"`; stage calls `run_select_openings()`
- **`src/timeseries.py`** — Loads catalog at entry, filters `df` to `model_tier == 1` ECOs, logs count
- **`src/engine_delta.py`** — Loads catalog at entry, filters openings list to `model_tier == 1`, logs count
- **`src/ingest.py`** — After writing `openings_ts.csv`, computes per-ECO long-tail stats (last_year_win_rate, total_games_last_year, trend_direction) and writes `data/output/long_tail_stats.csv`
- **`.github/workflows/update.yml`** — Inline Python script now calls `run_select_openings()` between `ingest()` and `run_timeseries()`; `git add` extended to include `data/openings_catalog.csv` and `data/output/long_tail_stats.csv`
- **`ARCHITECTURE.md`** — File structure tree: added `data/openings_catalog.csv` and `data/output/long_tail_stats.csv`; added `src/select_openings.py` with full module spec; updated `src/ingest.py` outputs; added `model_tier == 1` tier-filtering note to timeseries and engine_delta specs; added `"select"` stage to main.py spec; added constraint row for catalog coverage

## Selection rules

| Flag | Condition |
|---|---|
| `is_tracked_core` | `avg_monthly_games ≥ 1000` AND `months_with_data ≥ 24` |
| `is_long_tail` | `avg_monthly_games ≥ 100` AND NOT `is_tracked_core` |
| `model_tier = 1` | `is_tracked_core` |
| `model_tier = 2` | `is_long_tail` AND `avg_monthly_games ≥ 500` |
| `model_tier = 3` | `is_long_tail` AND `avg_monthly_games < 500`, or neither flag |
