### PR TITLE
feat: modular multi-page dashboard, per-opening detail pages, headline insights

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,13 +30,10 @@ jobs:
       - name: Install Python dependencies
         run: uv pip install --system -r requirements.txt
 
-      - name: Build dashboard.html
+      - name: Build modular dashboard
         # findings/findings.json is read by run_visualizer() if it exists;
         # if it has not been generated yet the dashboard still renders (graceful degradation).
         run: python -c "from src.visualizer import run_visualizer; run_visualizer()"
-
-      - name: Add index.html for GitHub Pages
-        run: cp data/output/dashboard.html data/output/index.html
 
       - name: Check if GitHub Pages is enabled
         id: pages-check
@@ -62,7 +59,7 @@ jobs:
         if: steps.pages-check.outputs.enabled == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: data/output/
+          path: data/output/dashboard/
 
       - name: Deploy to GitHub Pages
         if: steps.pages-check.outputs.enabled == 'true'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
-      # ── Rust toolchain & fetcher ──────────────────────────────────────────
+      # ── Rust toolchain & fetcher ─────────────────────────────────────────────────────
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
@@ -39,7 +39,7 @@ jobs:
         run: cargo build --release
         working-directory: fetcher
 
-      # ── Fetch missing months ──────────────────────────────────────────────
+      # ── Fetch missing months ─────────────────────────────────────────────────────────
       - name: Fetch missing months (incremental)
         id: fetch_step
         env:
@@ -128,7 +128,7 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
-      # ── Python environment ────────────────────────────────────────────────
+      # ── Python environment ──────────────────────────────────────────────────────────────
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -140,14 +140,14 @@ jobs:
       - name: Install Python dependencies
         run: uv pip install --system -r requirements.txt
 
-      # ── Stockfish ────────────────────────────────────────────────────────
+      # ── Stockfish ────────────────────────────────────────────────────────────────────
       - name: Install Stockfish
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y stockfish
 
-      # ── Pipeline ─────────────────────────────────────────────────────────
-      - name: Run ingest → timeseries → engine delta
+      # ── Pipeline ─────────────────────────────────────────────────────────────────────
+      - name: Run ingest → select → timeseries → engine delta
         run: |
           rm -f data/processed/openings_ts.csv \
                 data/output/forecasts.csv \
@@ -155,9 +155,11 @@ jobs:
                 data/output/dashboard.html
           python -c "
           from src.ingest import ingest
+          from src.select_openings import run_select_openings
           from src.timeseries import run_timeseries
           from src.engine_delta import run_engine_delta
           ingest()
+          run_select_openings()
           run_timeseries()
           run_engine_delta()
           "
@@ -168,7 +170,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/processed/openings_ts.csv \
                   data/output/forecasts.csv \
-                  data/output/engine_delta.csv
+                  data/output/engine_delta.csv \
+                  data/openings_catalog.csv \
+                  data/output/long_tail_stats.csv
           git diff --cached --quiet || git commit -m "chore: auto-update $(date +%Y-%m)"
           git push
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,7 +33,7 @@ Lichess Opening Explorer API
               centipawn scores ──▶  data/output/engine_delta.csv
         │
         ▼
-  [Visualizer]  ──── 3-panel Plotly HTML dashboard
+  [Visualizer]  ──── multi-page static site (data/output/dashboard/)
 ```
 
 **Key API constraint:** Lichess Explorer supports `since` and `until` as `YYYY-MM`
@@ -61,7 +61,15 @@ opencast/
 │   └── output/
 │       ├── forecasts.csv      ← ARIMA / HW forecasts with confidence intervals
 │       ├── engine_delta.csv   ← centipawn vs human win rate delta per opening
-│       └── long_tail_stats.csv ← descriptive stats for long-tail openings
+│       ├── long_tail_stats.csv ← descriptive stats for long-tail openings
+│       └── dashboard/         ← multi-page static site (served as GitHub Pages)
+│           ├── index.html     ← overview: headline insights + 3 panels
+│           ├── openings.html  ← sortable table of all openings
+│           ├── families.html  ← ECO family summary
+│           ├── opening_*.html ← per-opening detail pages (one per ECO)
+│           └── assets/
+│               ├── shared.css ← design tokens, nav, table, widget styles
+│               └── nav.js     ← active-link highlight script
 │
 ├── src/
 │   ├── __init__.py
@@ -69,7 +77,10 @@ opencast/
 │   ├── select_openings.py     ← computes selection flags and model tiers
 │   ├── timeseries.py          ← ARIMA (Tier 1) + Holt-Winters (Tier 2) + break detection
 │   ├── engine_delta.py        ← Stockfish eval → delta computation (Tier 1 only)
-│   └── visualizer.py          ← Plotly 3-panel dashboard (exports .html)
+│   ├── visualizer.py          ← multi-page static site generator
+│   └── assets/
+│       ├── shared.css         ← design tokens + component styles (source)
+│       └── nav.js             ← active-nav script (source)
 │
 ├── openings.json              ← config: ECO codes to track + move-8 FENs
 ├── main.py                    ← orchestrator: runs all pipeline stages in order
@@ -238,32 +249,50 @@ depth 20, hash 256MB.
 
 ### `src/visualizer.py` — Python
 
-**Responsibility:** Produce a 3-panel Plotly HTML dashboard from output CSVs.
+**Responsibility:** Generate a multi-page static HTML site from output CSVs.
+All pages share a navigation bar and design token set.
 
 **Interface:**
 ```
-INPUT  : data/output/forecasts.csv, data/output/engine_delta.csv
-OUTPUT : data/output/dashboard.html
+INPUT  : data/output/forecasts.csv
+         data/output/engine_delta.csv
+         data/openings_catalog.csv
+         findings/findings.json          (optional; graceful degradation if absent)
+OUTPUT : data/output/dashboard/          (directory; served as GitHub Pages root)
 ```
 
-**Panel 1 — Forecast chart (line + shaded CI)**
-- X: month, Y: white_win_rate
-- Solid line for actuals, dashed for forecast, shaded band for 95% CI
-- One trace per opening (5 openings max for readability)
-- Annotate detected structural breaks with vertical dashed lines
+**Page structure:**
 
-**Panel 2 — Engine delta scatter (bubble chart)**
-- X: engine centipawn score, Y: human win rate at 2000+
-- Diagonal reference line = "engine-expected" win rate
-- Bubble size = total game volume; color = ECO category (A/B/C/D/E)
-- Openings above the line: human skill amplifiers
-- Openings below the line: theory-heavy, engine-correct
+| File | Purpose |
+|---|---|
+| `index.html` | Overview: headline insights from findings.json + 3 Plotly panels |
+| `openings.html` | Sortable table of all openings with last win rate and engine delta |
+| `families.html` | ECO family summary (A–E) with avg win rate |
+| `opening_{ECO}.html` | Per-opening detail: Plotly forecast, engine box, AI narrative |
+| `assets/shared.css` | Design tokens, nav, table, widget component styles |
+| `assets/nav.js` | Active-link highlight script |
 
-**Panel 3 — ECO heatmap by rating bracket**
-- Y: ECO category (A/B/C/D/E), X: rating bucket (1200/1500/1800/2000/2200/2500)
-- Cell value: average white_win_rate
-- Color scale: diverging Red-White-Green centered at 0.50
-- Reveals which opening categories only work at low ELO
+**Render functions:**
+- `render_overview(forecasts, engine_df, findings_json)` → `index.html`
+- `render_openings_table(forecasts, engine_df, catalog)` → `openings.html`
+- `render_families(forecasts)` → `families.html`
+- `render_opening_page(eco, forecasts, engine_df, findings_json)` → `opening_{eco}.html`
+- `run_visualizer()` — orchestrates all four renders + asset copy
+
+**Design tokens** (preserved):
+```python
+PANEL_BG = "#121821"; GRID_COLOR = "rgba(148, 163, 184, 0.18)"; TEXT_PRIMARY = "#E6EEF8"
+TEXT_SECONDARY = "#9FB0C3"; ACCENT = "#57C7FF"
+ECO_COLORS = {"A":"#7CC7FF","B":"#7BE495","C":"#F6C177","D":"#F28DA6","E":"#B9A5FF"}
+BODY_FONT = "'DM Sans', system-ui, sans-serif"
+DISPLAY_FONT = "'DM Serif Display', Georgia, serif"
+```
+
+**`findings.json` contract for per-opening narratives:**
+```json
+{ "per_opening": { "B20": "narrative text ...", ... } }
+```
+Falls back to "No analysis available yet." if the key is absent.
 
 ---
 
@@ -344,3 +373,4 @@ requests
 | Opening catalogue coverage | openings_catalog.csv drives all pipeline stages; openings absent from it are silently ignored |
 | Engine delta CI budget | Total Stockfish evaluation must complete in < 5 min; warning logged if exceeded |
 | Timeseries per-ECO budget | Each ECO must complete in < 60s; warning logged if exceeded |
+| GitHub Pages root path | deploy.yml uploads `data/output/dashboard/`; `index.html` is the Pages entry point |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,7 +59,7 @@ opencast/
 │   │   └── openings_ts.csv    ← (month, eco, opening_name, rating, white, draws, black, total)
 │   ├── openings_catalog.csv   ← canonical opening catalogue with tier flags
 │   └── output/
-│       ├── forecasts.csv      ← ARIMA forecasts with confidence intervals
+│       ├── forecasts.csv      ← ARIMA / HW forecasts with confidence intervals
 │       ├── engine_delta.csv   ← centipawn vs human win rate delta per opening
 │       └── long_tail_stats.csv ← descriptive stats for long-tail openings
 │
@@ -67,8 +67,8 @@ opencast/
 │   ├── __init__.py
 │   ├── ingest.py              ← reads data/raw/ JSONs → openings_ts.csv
 │   ├── select_openings.py     ← computes selection flags and model tiers
-│   ├── timeseries.py          ← ARIMA fitting, forecasting, structural break detection
-│   ├── engine_delta.py        ← Stockfish eval → delta computation
+│   ├── timeseries.py          ← ARIMA (Tier 1) + Holt-Winters (Tier 2) + break detection
+│   ├── engine_delta.py        ← Stockfish eval → delta computation (Tier 1 only)
 │   └── visualizer.py          ← Plotly 3-panel dashboard (exports .html)
 │
 ├── openings.json              ← config: ECO codes to track + move-8 FENs
@@ -159,8 +159,8 @@ OUTPUT : data/openings_catalog.csv (updated in-place)
 
 ### `src/timeseries.py` — Python (primary differentiator)
 
-**Responsibility:** Fit ARIMA models on monthly win rate series and forecast
-3 months ahead. Detect structural breaks (regime changes in opening popularity).
+**Responsibility:** Fit models on monthly win rate series and forecast 3 months
+ahead. Dispatches to different model tiers based on opening data volume.
 
 **Interface:**
 ```
@@ -171,23 +171,26 @@ OUTPUT : data/output/forecasts.csv
 
 **Output schema:**
 ```
-eco | opening_name | month | actual | forecast | lower_ci | upper_ci | is_forecast
+eco | opening_name | month | actual | forecast | lower_ci | upper_ci | is_forecast | structural_break | model_tier
 ```
 
-**Pipeline per opening:**
-1. Extract monthly `white_win_rate` series (min 24 data points required)
-2. ADF test for stationarity — first-difference if non-stationary (d=1)
-3. Fit `ARIMA(p,d,q)` via `pmdarima.auto_arima` (information criterion: AIC)
-4. Forecast 3 months ahead with 95% confidence intervals
-5. Structural break detection via `statsmodels` Chow test at each month
-6. Ljung-Box test on residuals — log warning if autocorrelation remains
+**Tier structure:**
 
-**Tier filtering:** Only processes ECOs with `model_tier == 1` (Tier 2/3 added in Phase B).
+| Tier | Model | Extras | Condition |
+|---|---|---|---|
+| 1 | ARIMA (auto, AIC) | Chow break test + Ljung-Box | `model_tier == 1` |
+| 2 | Holt-Winters (`trend='add'`, no seasonality) | CI = ±1.96 × residual std | `model_tier == 2` |
+| 3 | Skipped | Descriptive stats only (logged) | `model_tier == 3` |
+
+**Per-ECO timing:** each ECO is timed with `time.perf_counter()`; a warning is
+logged if a single ECO exceeds 60s.
+
+**Summary log:**
+```
+Timeseries: N openings processed in X.Xs (Tier1: Xs avg, Tier2: Xs avg)
+```
 
 **Libraries:** `pmdarima`, `statsmodels`, `pandas`, `numpy`
-
-**Mathematical note:** Win probability from engine centipawn score uses the
-standard sigmoid transformation applied in engine delta module (see below).
 
 ---
 
@@ -211,6 +214,9 @@ eco | opening_name | engine_cp | p_engine | human_win_rate_2000 | delta | interp
 ```
 
 **Tier filtering:** Only evaluates ECOs with `model_tier == 1`.
+
+**Timing guardrail:** Total evaluation time is measured; a warning is logged if it
+exceeds 300s (5 min budget).
 
 **Centipawn → probability conversion:**
 
@@ -336,3 +342,5 @@ requests
 | Stockfish must be installed locally | Document path config in README |
 | Opening Explorer FENs must match mainline exactly | Validate FENs in openings.json against Lichess Explorer UI |
 | Opening catalogue coverage | openings_catalog.csv drives all pipeline stages; openings absent from it are silently ignored |
+| Engine delta CI budget | Total Stockfish evaluation must complete in < 5 min; warning logged if exceeded |
+| Timeseries per-ECO budget | Each ECO must complete in < 60s; warning logged if exceeded |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,13 +57,16 @@ opencast/
 │   ├── raw/                   ← JSON files from Rust fetcher (one per opening/month)
 │   ├── processed/
 │   │   └── openings_ts.csv    ← (month, eco, opening_name, rating, white, draws, black, total)
+│   ├── openings_catalog.csv   ← canonical opening catalogue with tier flags
 │   └── output/
 │       ├── forecasts.csv      ← ARIMA forecasts with confidence intervals
-│       └── engine_delta.csv   ← centipawn vs human win rate delta per opening
+│       ├── engine_delta.csv   ← centipawn vs human win rate delta per opening
+│       └── long_tail_stats.csv ← descriptive stats for long-tail openings
 │
 ├── src/
 │   ├── __init__.py
 │   ├── ingest.py              ← reads data/raw/ JSONs → openings_ts.csv
+│   ├── select_openings.py     ← computes selection flags and model tiers
 │   ├── timeseries.py          ← ARIMA fitting, forecasting, structural break detection
 │   ├── engine_delta.py        ← Stockfish eval → delta computation
 │   └── visualizer.py          ← Plotly 3-panel dashboard (exports .html)
@@ -116,6 +119,7 @@ with `?`, struct-based deserialization, file I/O with `std::fs`.
 ```
 INPUT  : data/raw/*.json
 OUTPUT : data/processed/openings_ts.csv
+         data/output/long_tail_stats.csv
 ```
 
 **Output schema:**
@@ -128,6 +132,28 @@ month | eco | opening_name | rating_bracket | white | draws | black | total | wh
 - Compute `white_win_rate = white / (white + draws + black)`
 - Drop rows where `total < 500` — statistically unreliable months
 - Flag months where `total < 2000` with a `low_confidence` boolean column
+- After writing `openings_ts.csv`, compute long-tail stats from catalog and write `long_tail_stats.csv`
+
+---
+
+### `src/select_openings.py` — Python
+
+**Responsibility:** Compute per-ECO selection flags and model tiers from time series
+data and merge them into `data/openings_catalog.csv`.
+
+**Interface:**
+```
+INPUT  : data/processed/openings_ts.csv
+         data/openings_catalog.csv
+OUTPUT : data/openings_catalog.csv (updated in-place)
+```
+
+**Selection rules:**
+- `is_tracked_core = True` if `avg_monthly_games ≥ 1000` AND `months_with_data ≥ 24`
+- `is_long_tail = True` if `avg_monthly_games ≥ 100` AND NOT `is_tracked_core`
+- `model_tier = 1` if `is_tracked_core`
+- `model_tier = 2` if `is_long_tail` AND `avg_monthly_games ≥ 500`
+- `model_tier = 3` if `is_long_tail` AND `avg_monthly_games < 500`
 
 ---
 
@@ -139,6 +165,7 @@ month | eco | opening_name | rating_bracket | white | draws | black | total | wh
 **Interface:**
 ```
 INPUT  : data/processed/openings_ts.csv
+         data/openings_catalog.csv
 OUTPUT : data/output/forecasts.csv
 ```
 
@@ -154,6 +181,8 @@ eco | opening_name | month | actual | forecast | lower_ci | upper_ci | is_foreca
 4. Forecast 3 months ahead with 95% confidence intervals
 5. Structural break detection via `statsmodels` Chow test at each month
 6. Ljung-Box test on residuals — log warning if autocorrelation remains
+
+**Tier filtering:** Only processes ECOs with `model_tier == 1` (Tier 2/3 added in Phase B).
 
 **Libraries:** `pmdarima`, `statsmodels`, `pandas`, `numpy`
 
@@ -172,6 +201,7 @@ actual human win rates.
 ```
 INPUT  : openings.json (ECO → FEN after move 8)
          data/processed/openings_ts.csv (for human win rates at 2000+ bracket)
+         data/openings_catalog.csv
 OUTPUT : data/output/engine_delta.csv
 ```
 
@@ -179,6 +209,8 @@ OUTPUT : data/output/engine_delta.csv
 ```
 eco | opening_name | engine_cp | p_engine | human_win_rate_2000 | delta | interpretation
 ```
+
+**Tier filtering:** Only evaluates ECOs with `model_tier == 1`.
 
 **Centipawn → probability conversion:**
 
@@ -239,6 +271,7 @@ already exists (avoid re-fetching).
 STAGES = {
     "fetch"   : True,   # set False after first run
     "ingest"  : True,
+    "select"  : True,
     "ts"      : True,
     "engine"  : True,
     "viz"     : True,
@@ -265,50 +298,6 @@ Covers 20 openings across ECO categories A–E, including:
 Sicilian Defense, London System, King's Indian Defense, Caro-Kann,
 Queen's Gambit Declined, Ruy Lopez, French Defense, King's Gambit,
 Dutch Defense, English Opening.
-
----
-
-## Task Breakdown
-
-### Phase 1 — Setup (Day 1)
-- [x] `cargo new fetcher` — init Rust project
-- [x] Add `reqwest`, `tokio`, `serde`, `serde_json`, `clap` to `Cargo.toml`
-- [x] Populate `openings.json` with 20 ECO codes and their move-8 FENs
-- [x] Create `data/raw/`, `data/processed/`, `data/output/` directories
-
-### Phase 2 — Rust Fetcher (Day 2–3)
-- [x] Write `models.rs`: serde structs matching Lichess Explorer API response
-- [x] Write `client.rs`: async GET with query params + 1s rate limit sleep
-- [x] Write `main.rs`: loop openings × months, write JSON to `data/raw/`
-- [x] Test against one opening (Sicilian, B20) before full batch run
-- [x] Full batch run: 20 openings × 39 months (2023-01 → 2026-03) = 780 JSON files
-
-### Phase 3 — Ingestion (Day 4)
-- [x] Write `ingest.py`: JSON → `openings_ts.csv` with schema above
-- [x] Filter low-confidence months (`total < 500`)
-- [x] Sanity-check: win rates confirmed in 0.46–0.51 range across all 20 openings
-
-### Phase 4 — ARIMA (Day 5–6)
-- [x] Write `timeseries.py`: ADF → auto_arima → forecast → break detection
-- [x] Validate residuals with Ljung-Box test for each fitted model (all 20 pass)
-- [x] Write `forecasts.csv` (840 rows: 780 actual + 60 forecast)
-
-### Phase 5 — Engine Delta (Day 7)
-- [x] Install Stockfish 16 binary (`/usr/games/stockfish`), configure path
-- [x] Write `engine_delta.py`: replay UCI moves via python-chess → get FEN → Stockfish depth-20 eval
-- [x] Compute sigmoid probability and delta, write `engine_delta.csv` (20 rows)
-- **Results:** 8 openings engine-favoured (delta < −0.04) — D70 Grünfeld (−0.0644), B01 Scandinavian (−0.0581), B07 Pirc (−0.0558), B06 Modern (−0.0526), E60 King's Indian (−0.0501), C20 King's Gambit (−0.0465), C00 French (−0.0423), B20 Sicilian (−0.0447). No opening shows humans outperforming engine at 2000-rated blitz.
-
-### Phase 6 — Visualization (Day 8)
-- [x] Write `visualizer.py`: 3-panel Plotly dashboard as `dashboard.html` (31KB, CDN-hosted JS)
-- [x] Panel 1: Forecast line chart + shaded 95% CI for top-5 openings (B20, C44, C00, B12, A10), structural breaks as dotted vertical lines
-- [x] Panel 2: Bubble chart — engine cp vs human win rate, diagonal reference, bubble size = total volume
-- [x] Panel 3: ECO-category × month heatmap, diverging red-white-green at 0.50
-- [x] `main.py` orchestrator with stage flags already in place
-
-### Phase 7 — Documentation (Day 9)
-- [x] `README.md`: hypothesis + engine-delta findings table + structural break narrative per opening
-- [x] All phases documented with actual metrics in ARCHITECTURE.md
 
 ---
 
@@ -346,3 +335,4 @@ requests
 | ARIMA requires ≥ 24 data points per opening | Fetch from 2023-01 → 2026-03 (27 months) |
 | Stockfish must be installed locally | Document path config in README |
 | Opening Explorer FENs must match mainline exactly | Validate FENs in openings.json against Lichess Explorer UI |
+| Opening catalogue coverage | openings_catalog.csv drives all pipeline stages; openings absent from it are silently ignored |

--- a/data/openings_catalog.csv
+++ b/data/openings_catalog.csv
@@ -1,0 +1,21 @@
+eco,name,eco_group,moves,is_tracked_core,is_long_tail,model_tier
+B20,Sicilian Defense,B,"e2e4,c7c5",True,False,1
+B12,Caro-Kann Defense,B,"e2e4,c7c6",True,False,1
+C00,French Defense,C,"e2e4,e7e6",True,False,1
+B01,Scandinavian Defense,B,"e2e4,d7d5",True,False,1
+C44,King's Pawn Game,C,"e2e4,e7e5",True,False,1
+C50,Italian Game,C,"e2e4,e7e5,g1f3,b8c6,f1c4",True,False,1
+C60,Ruy Lopez,C,"e2e4,e7e5,g1f3,b8c6,f1b5",True,False,1
+C20,King's Gambit,C,"e2e4,e7e5,f2f4",True,False,1
+D00,London System,D,"d2d4,d7d5,g1f3,g8f6,c1f4",True,False,1
+D06,Queen's Gambit,D,"d2d4,d7d5,c2c4",True,False,1
+D30,Queen's Gambit Declined,D,"d2d4,d7d5,c2c4,e7e6",True,False,1
+D70,Grunfeld Defense,D,"d2d4,g8f6,c2c4,g7g6,b1c3,d7d5",True,False,1
+E60,King's Indian Defense,E,"d2d4,g8f6,c2c4,g7g6,b1c3,f8g7",True,False,1
+E20,Nimzo-Indian Defense,E,"d2d4,g8f6,c2c4,e7e6,b1c3,f8b4",True,False,1
+A10,English Opening,A,c2c4,True,False,1
+A45,Trompowsky Attack,A,"d2d4,g8f6,c1g5",True,False,1
+B06,Modern Defense,B,"e2e4,g7g6",True,False,1
+A00,Polish Opening,A,b2b4,True,False,1
+C41,Philidor Defense,C,"e2e4,e7e5,g1f3,d7d6",True,False,1
+B07,Pirc Defense,B,"e2e4,d7d6,d2d4,g8f6",True,False,1

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ PROCESSED_CSV  = "data/processed/openings_ts.csv"
 CATALOG_CSV    = "data/openings_catalog.csv"
 FORECASTS_CSV  = "data/output/forecasts.csv"
 ENGINE_CSV     = "data/output/engine_delta.csv"
-DASHBOARD_HTML = "data/output/dashboard.html"
+DASHBOARD_HTML = "data/output/dashboard/index.html"
 FINDINGS_MD    = "FINDINGS.md"
 
 with open("config.json") as _f:
@@ -95,14 +95,12 @@ def get_missing_months() -> list[str]:
 
     missing_months = []
     for month in all_months:
-        # Month is complete only when every ECO has a file
         if any(f"{eco}_{month}" not in existing for eco in eco_codes):
             missing_months.append(month)
     return missing_months
 
 
 def _should_fetch_missing_data(missing: list[str]) -> bool:
-    """Decide whether to fetch missing data based on config, env, or prompt."""
     if STAGES.get("fetch", False):
         return True
     if not missing:
@@ -132,7 +130,6 @@ def _should_fetch_missing_data(missing: list[str]) -> bool:
 
 
 def _run_fetch_for_missing_months(missing: list[str]) -> bool:
-    """Fetch missing month range and return True if data was fetched."""
     if not missing:
         print("Fetch: all expected files present, nothing to do.")
         return False
@@ -170,7 +167,6 @@ def _run_fetch_for_missing_months(missing: list[str]) -> bool:
 
 
 def _skip_or_force(path: str, label: str, force: bool) -> bool:
-    """Skip existing output unless recompute is forced."""
     if force and os.path.exists(path):
         print(f"Recomputing {label}: ignoring existing {path} due to fresh fetch")
         return False

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ except Exception:  # pragma: no cover
 STAGES = {
     "fetch"  : False,  # set True to re-fetch from Lichess
     "ingest" : True,
+    "select" : True,
     "ts"     : True,
     "engine" : True,
     "viz"    : True,
@@ -20,6 +21,7 @@ STAGES = {
 }
 
 PROCESSED_CSV  = "data/processed/openings_ts.csv"
+CATALOG_CSV    = "data/openings_catalog.csv"
 FORECASTS_CSV  = "data/output/forecasts.csv"
 ENGINE_CSV     = "data/output/engine_delta.csv"
 DASHBOARD_HTML = "data/output/dashboard.html"
@@ -203,6 +205,11 @@ def main():
         print("--- Stage: ingest ---")
         from src.ingest import ingest
         ingest()
+
+    if STAGES["select"] and not _skip_or_force(CATALOG_CSV, "select", force_recompute):
+        print("--- Stage: select ---")
+        from src.select_openings import run_select_openings
+        run_select_openings()
 
     if STAGES["ts"] and not _skip_or_force(FORECASTS_CSV, "timeseries", force_recompute):
         print("--- Stage: timeseries ---")

--- a/src/assets/nav.js
+++ b/src/assets/nav.js
@@ -1,0 +1,17 @@
+// OpenCast nav.js — minimal JS for the shared navigation
+(function () {
+  'use strict';
+
+  // Mark the current page link as active based on the filename
+  var nav = document.getElementById('main-nav');
+  if (!nav) return;
+
+  var current = window.location.pathname.split('/').pop() || 'index.html';
+  var links = nav.querySelectorAll('a');
+  links.forEach(function (link) {
+    var href = link.getAttribute('href') || '';
+    if (href === current) {
+      link.classList.add('active');
+    }
+  });
+})();

--- a/src/assets/shared.css
+++ b/src/assets/shared.css
@@ -1,0 +1,147 @@
+/* OpenCast shared styles */
+
+:root {
+  --panel-bg:       #121821;
+  --text-primary:   #E6EEF8;
+  --text-secondary: #9FB0C3;
+  --accent:         #57C7FF;
+  --border-subtle:  rgba(148, 163, 184, 0.18);
+  --font-body:      'DM Sans', system-ui, sans-serif;
+  --font-display:   'DM Serif Display', Georgia, serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  background: var(--panel-bg);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  margin: 0;
+  min-height: 100vh;
+}
+
+/* Navigation */
+#main-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.75rem 2rem;
+  background: rgba(18, 24, 33, 0.95);
+  border-bottom: 1px solid var(--border-subtle);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+#main-nav .brand {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  color: var(--accent);
+  margin-right: auto;
+}
+
+#main-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+#main-nav a:hover,
+#main-nav a.active {
+  color: var(--text-primary);
+  background: var(--border-subtle);
+}
+
+/* Page titles */
+.page-title {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  color: var(--text-primary);
+  margin-bottom: 1.5rem;
+}
+
+h1, h2, h3 { font-family: var(--font-display); }
+
+/* Sections */
+.panel { margin-bottom: 3rem; }
+
+/* Headlines / insight widgets */
+.headlines {
+  margin-bottom: 2rem;
+}
+
+.insight-widget {
+  background: rgba(87, 199, 255, 0.06);
+  border-left: 3px solid var(--accent);
+  border-radius: 0 6px 6px 0;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.insight-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.insight-text { margin: 0; color: var(--text-primary); }
+
+/* Narrative box */
+.narrative {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+/* Engine eval box */
+.engine-box {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.engine-box h3 { margin-top: 0; }
+
+/* Data tables */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.data-table thead th {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+}
+
+.data-table tbody tr {
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.data-table tbody tr:hover {
+  background: rgba(87, 199, 255, 0.05);
+}

--- a/src/engine_delta.py
+++ b/src/engine_delta.py
@@ -10,6 +10,7 @@ from stockfish import Stockfish
 _HERE = os.path.dirname(__file__)
 OPENINGS_JSON = os.path.join(_HERE, "..", "openings.json")
 PROCESSED_CSV = os.path.join(_HERE, "..", "data", "processed", "openings_ts.csv")
+CATALOG_CSV   = os.path.join(_HERE, "..", "data", "openings_catalog.csv")
 OUTPUT_CSV    = os.path.join(_HERE, "..", "data", "output", "engine_delta.csv")
 OUTPUT_DIR    = os.path.join(_HERE, "..", "data", "output")
 
@@ -44,7 +45,15 @@ def _interpret(delta: float) -> str:
 
 def run_engine_delta() -> pd.DataFrame:
     with open(OPENINGS_JSON) as f:
-        openings = json.load(f)
+        all_openings = json.load(f)
+
+    # Filter to Tier-1 openings only
+    catalog = pd.read_csv(CATALOG_CSV)
+    tier1_ecos = set(catalog.loc[catalog["model_tier"] == 1, "eco"])
+    openings = [o for o in all_openings if o["eco"] in tier1_ecos]
+    import logging
+    log = logging.getLogger(__name__)
+    log.info("Engine delta: evaluating %d Tier-1 ECOs", len(openings))
 
     ts = pd.read_csv(PROCESSED_CSV)
     human_rates = (
@@ -96,14 +105,14 @@ def run_engine_delta() -> pd.DataFrame:
 
     df = pd.DataFrame(rows)
     df.to_csv(OUTPUT_CSV, index=False)
-    print(f"\nEngine delta written → {OUTPUT_CSV}  ({len(df)} rows)")
+    print(f"\nEngine delta written \u2192 {OUTPUT_CSV}  ({len(df)} rows)")
     return df
 
 
 def recommend_openings(delta_df: pd.DataFrame | None = None) -> pd.DataFrame:
     """Return openings ranked by delta (highest = most human-favourable).
 
-    A positive delta means humans outperform the engine prediction — these are
+    A positive delta means humans outperform the engine prediction \u2014 these are
     the best openings to play at 2000-rated blitz relative to engine expectation.
     """
     if delta_df is None:

--- a/src/engine_delta.py
+++ b/src/engine_delta.py
@@ -1,7 +1,9 @@
 import json
+import logging
 import math
 import os
 import shutil
+import time
 
 import chess
 import pandas as pd
@@ -17,6 +19,9 @@ OUTPUT_DIR    = os.path.join(_HERE, "..", "data", "output")
 STOCKFISH_PATH = shutil.which("stockfish") or "/usr/games/stockfish"
 DEPTH = 20
 HASH_MB = 256
+ENGINE_TOTAL_WARN_S = 300.0  # warn if total evaluation exceeds 5 min
+
+log = logging.getLogger(__name__)
 
 
 def _get_fen_from_uci_moves(uci_moves: str) -> str:
@@ -36,9 +41,9 @@ def _cp_to_prob(cp: int) -> float:
 
 def _interpret(delta: float) -> str:
     if delta > 0.04:
-        return "humans outperform engine — rewards human skill"
+        return "humans outperform engine \u2014 rewards human skill"
     elif delta < -0.04:
-        return "engine-favoured — frequently misplayed or theory-heavy"
+        return "engine-favoured \u2014 frequently misplayed or theory-heavy"
     else:
         return "consistent with engine evaluation"
 
@@ -51,8 +56,6 @@ def run_engine_delta() -> pd.DataFrame:
     catalog = pd.read_csv(CATALOG_CSV)
     tier1_ecos = set(catalog.loc[catalog["model_tier"] == 1, "eco"])
     openings = [o for o in all_openings if o["eco"] in tier1_ecos]
-    import logging
-    log = logging.getLogger(__name__)
     log.info("Engine delta: evaluating %d Tier-1 ECOs", len(openings))
 
     ts = pd.read_csv(PROCESSED_CSV)
@@ -68,6 +71,7 @@ def run_engine_delta() -> pd.DataFrame:
         depth=DEPTH,
         parameters={"Hash": HASH_MB, "Threads": 1},
     )
+    t_start = time.perf_counter()
     try:
         for opening in openings:
             eco   = opening["eco"]
@@ -103,6 +107,14 @@ def run_engine_delta() -> pd.DataFrame:
     finally:
         del sf
 
+    total_elapsed = time.perf_counter() - t_start
+    log.info("Engine delta: completed in %.1fs", total_elapsed)
+    if total_elapsed > ENGINE_TOTAL_WARN_S:
+        log.warning(
+            "WARNING: engine_delta total time %.1fs exceeded 5 min budget",
+            total_elapsed,
+        )
+
     df = pd.DataFrame(rows)
     df.to_csv(OUTPUT_CSV, index=False)
     print(f"\nEngine delta written \u2192 {OUTPUT_CSV}  ({len(df)} rows)")
@@ -110,11 +122,7 @@ def run_engine_delta() -> pd.DataFrame:
 
 
 def recommend_openings(delta_df: pd.DataFrame | None = None) -> pd.DataFrame:
-    """Return openings ranked by delta (highest = most human-favourable).
-
-    A positive delta means humans outperform the engine prediction \u2014 these are
-    the best openings to play at 2000-rated blitz relative to engine expectation.
-    """
+    """Return openings ranked by delta (highest = most human-favourable)."""
     if delta_df is None:
         delta_df = pd.read_csv(OUTPUT_CSV)
     return (

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -2,13 +2,16 @@ import json
 import os
 import re
 
+import numpy as np
 import pandas as pd
 
 _HERE = os.path.dirname(__file__)
 RAW_DIR = os.path.join(_HERE, "..", "data", "raw")
 PROCESSED_DIR = os.path.join(_HERE, "..", "data", "processed")
 OPENINGS_JSON = os.path.join(_HERE, "..", "openings.json")
-OUTPUT_CSV = os.path.join(PROCESSED_DIR, "openings_ts.csv")
+CATALOG_CSV   = os.path.join(_HERE, "..", "data", "openings_catalog.csv")
+OUTPUT_CSV    = os.path.join(PROCESSED_DIR, "openings_ts.csv")
+LONG_TAIL_CSV = os.path.join(_HERE, "..", "data", "output", "long_tail_stats.csv")
 
 RATING_BRACKET = 2000
 MIN_GAMES = 500
@@ -21,6 +24,59 @@ def _load_name_map() -> dict:
     with open(OPENINGS_JSON) as f:
         openings = json.load(f)
     return {o["eco"]: o["name"] for o in openings}
+
+
+def _compute_long_tail_stats(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute descriptive stats for long-tail openings from catalog."""
+    if not os.path.exists(CATALOG_CSV):
+        return pd.DataFrame(columns=["eco", "name", "last_year_win_rate",
+                                     "total_games_last_year", "trend_direction"])
+
+    catalog = pd.read_csv(CATALOG_CSV)
+    long_tail_ecos = set(
+        catalog.loc[catalog["is_long_tail"] == True, "eco"]
+    )
+
+    if not long_tail_ecos:
+        return pd.DataFrame(columns=["eco", "name", "last_year_win_rate",
+                                     "total_games_last_year", "trend_direction"])
+
+    name_map = catalog.set_index("eco")["name"].to_dict()
+
+    rows = []
+    for eco in long_tail_ecos:
+        grp = df[df["eco"] == eco].sort_values("month")
+        if grp.empty:
+            continue
+
+        last12 = grp.tail(12)
+        last_year_win_rate    = float(last12["white_win_rate"].mean())
+        total_games_last_year = int(last12["total"].sum())
+
+        # Slope for trend direction
+        y = last12["white_win_rate"].values.astype(float)
+        if len(y) >= 2:
+            x = np.arange(len(y), dtype=float)
+            slope = float(np.polyfit(x, y, 1)[0])
+        else:
+            slope = 0.0
+
+        if slope > 0.001:
+            trend_direction = "rising"
+        elif slope < -0.001:
+            trend_direction = "falling"
+        else:
+            trend_direction = "stable"
+
+        rows.append({
+            "eco":                  eco,
+            "name":                 name_map.get(eco, eco),
+            "last_year_win_rate":   round(last_year_win_rate, 6),
+            "total_games_last_year": total_games_last_year,
+            "trend_direction":      trend_direction,
+        })
+
+    return pd.DataFrame(rows)
 
 
 def ingest() -> pd.DataFrame:
@@ -60,7 +116,14 @@ def ingest() -> pd.DataFrame:
 
     df = pd.DataFrame(rows)
     df.to_csv(OUTPUT_CSV, index=False)
-    print(f"Ingested {len(df)} rows → {OUTPUT_CSV}")
+    print(f"Ingested {len(df)} rows \u2192 {OUTPUT_CSV}")
+
+    # Write long-tail stats
+    os.makedirs(os.path.dirname(LONG_TAIL_CSV), exist_ok=True)
+    long_tail_df = _compute_long_tail_stats(df)
+    long_tail_df.to_csv(LONG_TAIL_CSV, index=False)
+    print(f"Long-tail stats written \u2192 {LONG_TAIL_CSV}  ({len(long_tail_df)} rows)")
+
     return df
 
 

--- a/src/select_openings.py
+++ b/src/select_openings.py
@@ -1,0 +1,139 @@
+"""Compute opening selection flags and model tiers from openings_ts.csv.
+
+Reads data/processed/openings_ts.csv, computes per-ECO statistics, applies
+selection rules, and merges results into data/openings_catalog.csv.
+"""
+
+import logging
+import os
+
+import numpy as np
+import pandas as pd
+
+_HERE = os.path.dirname(__file__)
+PROCESSED_CSV = os.path.join(_HERE, "..", "data", "processed", "openings_ts.csv")
+CATALOG_CSV   = os.path.join(_HERE, "..", "data", "openings_catalog.csv")
+
+MIN_GAMES_CORE     = 1000
+MIN_MONTHS_CORE    = 24
+MIN_GAMES_LONGTAIL = 100
+MIN_GAMES_TIER2    = 500
+
+log = logging.getLogger(__name__)
+
+
+def _compute_eco_stats(ts: pd.DataFrame) -> pd.DataFrame:
+    """Compute per-ECO aggregate statistics from the time series dataframe."""
+    rows = []
+    for eco, grp in ts.groupby("eco"):
+        grp = grp.sort_values("month").reset_index(drop=True)
+
+        avg_monthly_games  = float(grp["total"].mean())
+        months_with_data   = int((grp["total"] >= 500).sum())
+
+        # Linear regression slope of white_win_rate over time (index as x)
+        y = grp["white_win_rate"].values.astype(float)
+        if len(y) >= 2:
+            x = np.arange(len(y), dtype=float)
+            win_rate_slope = float(np.polyfit(x, y, 1)[0])
+        else:
+            win_rate_slope = 0.0
+
+        rows.append({
+            "eco": eco,
+            "avg_monthly_games": avg_monthly_games,
+            "months_with_data":  months_with_data,
+            "win_rate_slope":    win_rate_slope,
+        })
+    return pd.DataFrame(rows)
+
+
+def _apply_selection_rules(stats: pd.DataFrame) -> pd.DataFrame:
+    """Apply is_tracked_core, is_long_tail, and model_tier flags to stats."""
+    stats = stats.copy()
+
+    stats["is_tracked_core"] = (
+        (stats["avg_monthly_games"] >= MIN_GAMES_CORE) &
+        (stats["months_with_data"]  >= MIN_MONTHS_CORE)
+    )
+    stats["is_long_tail"] = (
+        (stats["avg_monthly_games"] >= MIN_GAMES_LONGTAIL) &
+        (~stats["is_tracked_core"])
+    )
+
+    def _tier(row: pd.Series) -> int:
+        if row["is_tracked_core"]:
+            return 1
+        if row["is_long_tail"] and row["avg_monthly_games"] >= MIN_GAMES_TIER2:
+            return 2
+        if row["is_long_tail"]:
+            return 3
+        return 3  # everything else gets Tier 3 by default
+
+    stats["model_tier"] = stats.apply(_tier, axis=1)
+    return stats
+
+
+def run_select_openings() -> pd.DataFrame:
+    """Compute selection flags and merge into openings_catalog.csv.
+
+    Returns the updated catalog DataFrame.
+    """
+    ts = pd.read_csv(PROCESSED_CSV)
+    log.info("select_openings: loaded %d rows from %s", len(ts), PROCESSED_CSV)
+
+    stats = _compute_eco_stats(ts)
+    stats = _apply_selection_rules(stats)
+
+    log.info(
+        "select_openings: %d core, %d long-tail, %d other ECOs computed",
+        int(stats["is_tracked_core"].sum()),
+        int(stats["is_long_tail"].sum()),
+        int((~stats["is_tracked_core"] & ~stats["is_long_tail"]).sum()),
+    )
+
+    # Load existing catalog
+    catalog = pd.read_csv(CATALOG_CSV)
+
+    # For existing catalog rows, update the computed flag columns
+    stat_cols = ["is_tracked_core", "is_long_tail", "model_tier"]
+    stats_indexed = stats.set_index("eco")
+
+    for col in stat_cols:
+        catalog[col] = catalog["eco"].map(
+            lambda eco, c=col: stats_indexed.at[eco, c]
+            if eco in stats_indexed.index
+            else catalog.loc[catalog["eco"] == eco, c].values[0]
+        )
+
+    # Append new ECOs found in ts but not yet in catalog
+    known_ecos = set(catalog["eco"])
+    new_rows = []
+    for _, stat_row in stats.iterrows():
+        eco = stat_row["eco"]
+        if eco in known_ecos:
+            continue
+        # For newly discovered ECOs we don't have a name or moves — leave blank
+        # for a human to fill in; flags are computed from data.
+        new_rows.append({
+            "eco":             eco,
+            "name":            "",
+            "eco_group":       eco[0],
+            "moves":           "",
+            "is_tracked_core": bool(stat_row["is_tracked_core"]),
+            "is_long_tail":    bool(stat_row["is_long_tail"]),
+            "model_tier":      int(stat_row["model_tier"]),
+        })
+
+    if new_rows:
+        log.info("select_openings: appending %d new ECOs to catalog", len(new_rows))
+        catalog = pd.concat([catalog, pd.DataFrame(new_rows)], ignore_index=True)
+
+    catalog.to_csv(CATALOG_CSV, index=False)
+    log.info("select_openings: catalog updated → %s  (%d rows)", CATALOG_CSV, len(catalog))
+    return catalog
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    run_select_openings()

--- a/src/timeseries.py
+++ b/src/timeseries.py
@@ -15,7 +15,8 @@ warnings.filterwarnings("ignore")
 
 _HERE = os.path.dirname(__file__)
 PROCESSED_CSV = os.path.join(_HERE, "..", "data", "processed", "openings_ts.csv")
-OUTPUT_CSV = os.path.join(_HERE, "..", "data", "output", "forecasts.csv")
+CATALOG_CSV   = os.path.join(_HERE, "..", "data", "openings_catalog.csv")
+OUTPUT_CSV    = os.path.join(_HERE, "..", "data", "output", "forecasts.csv")
 
 MIN_POINTS = 24
 FORECAST_STEPS = 3
@@ -46,7 +47,7 @@ def _chow_test(y: np.ndarray, bp: int) -> tuple:
         return 0.0, 1.0
 
     rss_before = sm.OLS(y[:bp], sm.add_constant(t[:bp])).fit().ssr
-    rss_after = sm.OLS(y[bp:], sm.add_constant(t[bp:])).fit().ssr
+    rss_after  = sm.OLS(y[bp:], sm.add_constant(t[bp:])).fit().ssr
 
     k = 2  # intercept + slope
     denom = rss_before + rss_after
@@ -74,6 +75,12 @@ def run_timeseries(df: pd.DataFrame | None = None) -> pd.DataFrame:
     else:
         df = df.copy()
 
+    # Filter to Tier-1 openings only
+    catalog = pd.read_csv(CATALOG_CSV)
+    tier1_ecos = set(catalog.loc[catalog["model_tier"] == 1, "eco"])
+    df = df[df["eco"].isin(tier1_ecos)]
+    log.info("Timeseries: processing %d Tier-1 ECOs", len(tier1_ecos))
+
     df["month"] = pd.to_datetime(df["month"])
     os.makedirs(os.path.dirname(OUTPUT_CSV), exist_ok=True)
 
@@ -85,7 +92,7 @@ def run_timeseries(df: pd.DataFrame | None = None) -> pd.DataFrame:
         n = len(grp)
 
         if n < MIN_POINTS:
-            log.warning("%s: only %d data points, need ≥ %d — skipping", eco, n, MIN_POINTS)
+            log.warning("%s: only %d data points, need \u2265 %d \u2014 skipping", eco, n, MIN_POINTS)
             continue
 
         y = np.asarray(grp["white_win_rate"].values, dtype=float)
@@ -154,7 +161,7 @@ def run_timeseries(df: pd.DataFrame | None = None) -> pd.DataFrame:
 
     out = pd.DataFrame(records, columns=OUTPUT_COLUMNS)
     out.to_csv(OUTPUT_CSV, index=False)
-    print(f"Forecasts written → {OUTPUT_CSV}  ({len(out)} rows)")
+    print(f"Forecasts written \u2192 {OUTPUT_CSV}  ({len(out)} rows)")
     return out
 
 

--- a/src/timeseries.py
+++ b/src/timeseries.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 import warnings
 
 import numpy as np
@@ -8,6 +9,7 @@ import statsmodels.api as sm
 from scipy import stats
 from statsmodels.tsa.stattools import adfuller
 from statsmodels.stats.diagnostic import acorr_ljungbox
+from statsmodels.tsa.holtwinters import ExponentialSmoothing
 
 import pmdarima as pm
 
@@ -30,10 +32,13 @@ OUTPUT_COLUMNS = [
     "upper_ci",
     "is_forecast",
     "structural_break",
+    "model_tier",
 ]
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
+
+ECO_TIMING_WARN_S = 60.0  # warn if a single ECO takes longer than this
 
 
 def _chow_test(y: np.ndarray, bp: int) -> tuple:
@@ -75,18 +80,24 @@ def run_timeseries(df: pd.DataFrame | None = None) -> pd.DataFrame:
     else:
         df = df.copy()
 
-    # Filter to Tier-1 openings only
+    # Load catalog and split into tiers
     catalog = pd.read_csv(CATALOG_CSV)
     tier1_ecos = set(catalog.loc[catalog["model_tier"] == 1, "eco"])
-    df = df[df["eco"].isin(tier1_ecos)]
+    tier2_ecos = set(catalog.loc[catalog["model_tier"] == 2, "eco"])
+    tier3_ecos = set(catalog.loc[catalog["model_tier"] == 3, "eco"])
     log.info("Timeseries: processing %d Tier-1 ECOs", len(tier1_ecos))
 
     df["month"] = pd.to_datetime(df["month"])
     os.makedirs(os.path.dirname(OUTPUT_CSV), exist_ok=True)
 
     records = []
+    tier1_times: list[float] = []
+    tier2_times: list[float] = []
 
-    for eco, grp in df.groupby("eco"):
+    # ── Tier 1: ARIMA + Chow + Ljung-Box ─────────────────────────────────────
+    tier1_df = df[df["eco"].isin(tier1_ecos)]
+    for eco, grp in tier1_df.groupby("eco"):
+        t0 = time.perf_counter()
         grp = grp.sort_values("month").reset_index(drop=True)
         opening_name = grp["opening_name"].iloc[0]
         n = len(grp)
@@ -143,6 +154,7 @@ def run_timeseries(df: pd.DataFrame | None = None) -> pd.DataFrame:
                 "upper_ci": None,
                 "is_forecast": False,
                 "structural_break": row["month"] in break_months,
+                "model_tier": 1,
             })
 
         # Forecast rows
@@ -157,7 +169,85 @@ def run_timeseries(df: pd.DataFrame | None = None) -> pd.DataFrame:
                 "upper_ci": round(float(ci[1]), 6),
                 "is_forecast": True,
                 "structural_break": False,
+                "model_tier": 1,
             })
+
+        elapsed = time.perf_counter() - t0
+        tier1_times.append(elapsed)
+        if elapsed > ECO_TIMING_WARN_S:
+            log.warning("%s (Tier 1): took %.1fs, exceeds %.0fs budget", eco, elapsed, ECO_TIMING_WARN_S)
+
+    # ── Tier 2: Holt-Winters (additive trend, no seasonality) ────────────────
+    tier2_df = df[df["eco"].isin(tier2_ecos)]
+    for eco, grp in tier2_df.groupby("eco"):
+        t0 = time.perf_counter()
+        grp = grp.sort_values("month").reset_index(drop=True)
+        opening_name = grp["opening_name"].iloc[0]
+
+        y = np.asarray(grp["white_win_rate"].values, dtype=float)
+        months = grp["month"].tolist()
+
+        if len(y) < 6:  # need at least 6 points for HW with additive trend
+            log.warning("%s (Tier 2): only %d data points, skipping", eco, len(y))
+            continue
+
+        hw_fit = ExponentialSmoothing(y, trend="add", seasonal=None).fit()
+        hw_forecast = hw_fit.forecast(FORECAST_STEPS)
+        residual_std = float(np.std(hw_fit.resid, ddof=1))
+        half_ci = 1.96 * residual_std
+
+        last_month = months[-1]
+        future_months = pd.date_range(start=last_month, periods=FORECAST_STEPS + 1, freq="MS")[1:]
+
+        # Historical rows
+        for _, row in grp.iterrows():
+            records.append({
+                "eco": eco,
+                "opening_name": opening_name,
+                "month": row["month"].strftime("%Y-%m"),
+                "actual": row["white_win_rate"],
+                "forecast": None,
+                "lower_ci": None,
+                "upper_ci": None,
+                "is_forecast": False,
+                "structural_break": False,
+                "model_tier": 2,
+            })
+
+        # Forecast rows
+        for fm, fc in zip(future_months, hw_forecast):
+            records.append({
+                "eco": eco,
+                "opening_name": opening_name,
+                "month": fm.strftime("%Y-%m"),
+                "actual": None,
+                "forecast": round(float(fc), 6),
+                "lower_ci": round(float(fc) - half_ci, 6),
+                "upper_ci": round(float(fc) + half_ci, 6),
+                "is_forecast": True,
+                "structural_break": False,
+                "model_tier": 2,
+            })
+
+        elapsed = time.perf_counter() - t0
+        tier2_times.append(elapsed)
+        if elapsed > ECO_TIMING_WARN_S:
+            log.warning("%s (Tier 2): took %.1fs, exceeds %.0fs budget", eco, elapsed, ECO_TIMING_WARN_S)
+
+    # ── Tier 3: descriptive stats only, no rows written ───────────────────────
+    log.info("Timeseries: skipping %d Tier-3 ECOs (descriptive stats only)", len(tier3_ecos))
+
+    # ── Summary log ───────────────────────────────────────────────────────────
+    total_s = sum(tier1_times) + sum(tier2_times)
+    t1_avg = sum(tier1_times) / len(tier1_times) if tier1_times else 0.0
+    t2_avg = sum(tier2_times) / len(tier2_times) if tier2_times else 0.0
+    log.info(
+        "Timeseries: %d openings processed in %.1fs (Tier1: %.1fs avg, Tier2: %.1fs avg)",
+        len(tier1_times) + len(tier2_times),
+        total_s,
+        t1_avg,
+        t2_avg,
+    )
 
     out = pd.DataFrame(records, columns=OUTPUT_COLUMNS)
     out.to_csv(OUTPUT_CSV, index=False)

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -4,13 +4,14 @@ from pathlib import Path
 
 import pandas as pd
 import plotly.graph_objects as go
-from plotly.subplots import make_subplots
 
 _HERE = os.path.dirname(__file__)
-FORECASTS_CSV  = os.path.join(_HERE, "..", "data", "output", "forecasts.csv")
-ENGINE_CSV     = os.path.join(_HERE, "..", "data", "output", "engine_delta.csv")
-OUTPUT_HTML    = os.path.join(_HERE, "..", "data", "output", "dashboard.html")
-FINDINGS_JSON  = os.path.join(_HERE, "..", "findings", "findings.json")
+FORECASTS_CSV = os.path.join(_HERE, "..", "data", "output", "forecasts.csv")
+ENGINE_CSV    = os.path.join(_HERE, "..", "data", "output", "engine_delta.csv")
+CATALOG_CSV   = os.path.join(_HERE, "..", "data", "openings_catalog.csv")
+FINDINGS_JSON = os.path.join(_HERE, "..", "findings", "findings.json")
+OUTPUT_DIR    = os.path.join(_HERE, "..", "data", "output", "dashboard")
+ASSETS_DIR    = os.path.join(OUTPUT_DIR, "assets")
 
 # ── Design tokens ─────────────────────────────────────────────────────────────
 PANEL_BG       = "#121821"
@@ -19,9 +20,8 @@ TEXT_PRIMARY   = "#E6EEF8"
 TEXT_SECONDARY = "#9FB0C3"
 ACCENT         = "#57C7FF"
 ECO_COLORS     = {"A": "#7CC7FF", "B": "#7BE495", "C": "#F6C177", "D": "#F28DA6", "E": "#B9A5FF"}
-
-PANEL1_ECOS = ["B20", "C44", "C00", "B12", "A10"]
-LINE_COLORS = ["#57C7FF", "#7BE495", "#F6C177", "#F28DA6", "#B9A5FF"]
+BODY_FONT      = "'DM Sans', system-ui, sans-serif"
+DISPLAY_FONT   = "'DM Serif Display', Georgia, serif"
 
 FORECAST_COLUMNS = [
     "eco",
@@ -36,10 +36,11 @@ FORECAST_COLUMNS = [
     "model_tier",
 ]
 
-BODY_FONT    = "'DM Sans', system-ui, sans-serif"
-DISPLAY_FONT = "'DM Serif Display', Georgia, serif"
+PANEL1_ECOS = ["B20", "C44", "C00", "B12", "A10"]
+LINE_COLORS  = ["#57C7FF", "#7BE495", "#F6C177", "#F28DA6", "#B9A5FF"]
 
 
+# ── Private helpers ──────────────────────────────────────────────────────────────
 def _apply_plotly_typography(fig: go.Figure, title_size: int) -> None:
     fig.update_layout(
         font=dict(family=BODY_FONT, color=TEXT_PRIMARY),
@@ -60,14 +61,12 @@ def _apply_plotly_typography(fig: go.Figure, title_size: int) -> None:
 
 
 def _safe_read_forecasts() -> pd.DataFrame:
-    """Read forecasts.csv safely, returning an empty DataFrame on failure."""
     try:
         df = pd.read_csv(FORECASTS_CSV)
     except FileNotFoundError:
         return pd.DataFrame(columns=FORECAST_COLUMNS)
     except Exception:
         return pd.DataFrame(columns=FORECAST_COLUMNS)
-
     for col in FORECAST_COLUMNS:
         if col not in df.columns:
             df[col] = None
@@ -75,7 +74,6 @@ def _safe_read_forecasts() -> pd.DataFrame:
 
 
 def _top5_by_volume(forecasts: pd.DataFrame) -> list[str]:
-    """Return up to 5 ECO codes with the highest total actual game volume."""
     actuals = forecasts[forecasts["is_forecast"] == False].copy()
     if actuals.empty or "actual" not in actuals.columns:
         return PANEL1_ECOS[:]
@@ -89,28 +87,21 @@ def _top5_by_volume(forecasts: pd.DataFrame) -> list[str]:
 
 
 def _build_panel1_figure(forecasts: pd.DataFrame) -> go.Figure:
-    """Panel 1: win rate forecast lines with CI shading and break annotations."""
     fig = go.Figure()
     top_ecos = _top5_by_volume(forecasts)
-
     for eco, color in zip(top_ecos, LINE_COLORS):
         grp = forecasts[forecasts["eco"] == eco].copy()
         if grp.empty:
             continue
         grp["month"] = pd.to_datetime(grp["month"])
         grp = grp.sort_values("month")
-
-        actuals  = grp[grp["is_forecast"] == False]
-        fc_rows  = grp[grp["is_forecast"] == True]
-
-        # Actual line
+        actuals = grp[grp["is_forecast"] == False]
+        fc_rows = grp[grp["is_forecast"] == True]
         fig.add_trace(go.Scatter(
             x=actuals["month"], y=actuals["actual"],
             name=eco, mode="lines",
             line=dict(color=color, width=2),
         ))
-
-        # Forecast line (dashed)
         if not fc_rows.empty:
             fig.add_trace(go.Scatter(
                 x=fc_rows["month"], y=fc_rows["forecast"],
@@ -118,91 +109,62 @@ def _build_panel1_figure(forecasts: pd.DataFrame) -> go.Figure:
                 line=dict(color=color, dash="dash", width=1.5),
                 showlegend=False,
             ))
-            # CI band
             fig.add_trace(go.Scatter(
                 x=pd.concat([fc_rows["month"], fc_rows["month"].iloc[::-1]]),
                 y=pd.concat([fc_rows["upper_ci"], fc_rows["lower_ci"].iloc[::-1]]),
                 fill="toself",
                 fillcolor=color.replace("#", "rgba(") + ",0.12)",
                 line=dict(color="rgba(0,0,0,0)"),
-                showlegend=False,
-                name=f"{eco} CI",
+                showlegend=False, name=f"{eco} CI",
             ))
-
-        # Structural break lines
         breaks = actuals[actuals["structural_break"] == True]["month"]
         for brk in breaks:
             fig.add_vline(
                 x=brk.timestamp() * 1000,
                 line=dict(color=color, dash="dot", width=1),
             )
-
-    fig.update_layout(title="Win Rate Forecast by Opening", xaxis_title="Month", yaxis_title="White Win Rate")
+    fig.update_layout(title="Win Rate Forecast by Opening",
+                      xaxis_title="Month", yaxis_title="White Win Rate")
     _apply_plotly_typography(fig, title_size=16)
     return fig
 
 
 def _build_panel2_figure(engine_df: pd.DataFrame) -> go.Figure:
-    """Panel 2: engine delta bubble chart."""
     fig = go.Figure()
-
     if engine_df.empty:
         _apply_plotly_typography(fig, title_size=16)
         return fig
-
     for eco_cat, color in ECO_COLORS.items():
         sub = engine_df[engine_df["eco"].str.startswith(eco_cat)]
         if sub.empty:
             continue
         fig.add_trace(go.Scatter(
-            x=sub["engine_cp"],
-            y=sub["human_win_rate_2000"],
-            mode="markers+text",
-            name=f"ECO {eco_cat}",
-            text=sub["eco"],
-            textposition="top center",
-            marker=dict(
-                color=color,
-                size=12,
-                opacity=0.85,
-                line=dict(width=1, color=PANEL_BG),
-            ),
-            hovertemplate=(
-                "<b>%{text}</b><br>"
-                "Engine cp: %{x}<br>"
-                "Human win rate: %{y:.3f}<br>"
-                "<extra></extra>"
-            ),
+            x=sub["engine_cp"], y=sub["human_win_rate_2000"],
+            mode="markers+text", name=f"ECO {eco_cat}",
+            text=sub["eco"], textposition="top center",
+            marker=dict(color=color, size=12, opacity=0.85,
+                        line=dict(width=1, color=PANEL_BG)),
+            hovertemplate="<b>%{text}</b><br>Engine cp: %{x}<br>Human win rate: %{y:.3f}<br><extra></extra>",
         ))
-
-    # Reference diagonal (engine-expected win rate)
     cp_range = list(range(-300, 301, 10))
     ref_probs = [1.0 / (1.0 + 10 ** (-cp / 400)) for cp in cp_range]
     fig.add_trace(go.Scatter(
-        x=cp_range, y=ref_probs,
-        mode="lines",
-        name="Engine expected",
+        x=cp_range, y=ref_probs, mode="lines", name="Engine expected",
         line=dict(color=TEXT_SECONDARY, dash="dash", width=1),
     ))
-
-    fig.update_layout(
-        title="Engine Delta: Human vs Engine Win Rate",
-        xaxis_title="Engine centipawn score",
-        yaxis_title="Human win rate (2000+)",
-    )
+    fig.update_layout(title="Engine Delta: Human vs Engine Win Rate",
+                      xaxis_title="Engine centipawn score",
+                      yaxis_title="Human win rate (2000+)")
     _apply_plotly_typography(fig, title_size=16)
     return fig
 
 
 def _build_panel3_figure(forecasts: pd.DataFrame) -> go.Figure:
-    """Panel 3: ECO heatmap by rating bracket."""
     fig = go.Figure()
-
     actuals = forecasts[forecasts["is_forecast"] == False].copy()
     if actuals.empty:
         _apply_plotly_typography(fig, title_size=16)
         return fig
-
     actuals["eco_group"] = actuals["eco"].str[0]
     pivot = (
         actuals.groupby(["eco_group", "rating_bracket"])["actual"]
@@ -211,23 +173,13 @@ def _build_panel3_figure(forecasts: pd.DataFrame) -> go.Figure:
         if "rating_bracket" in actuals.columns
         else actuals.groupby("eco_group")["actual"].mean().to_frame()
     )
-
-    z    = pivot.values
-    xlab = [str(c) for c in pivot.columns]
-    ylab = list(pivot.index)
-
     fig.add_trace(go.Heatmap(
-        z=z, x=xlab, y=ylab,
-        colorscale="RdYlGn",
-        zmid=0.50,
+        z=pivot.values, x=[str(c) for c in pivot.columns], y=list(pivot.index),
+        colorscale="RdYlGn", zmid=0.50,
         colorbar=dict(title="Win rate", tickfont=dict(color=TEXT_SECONDARY)),
     ))
-
-    fig.update_layout(
-        title="Average White Win Rate by ECO Family & Rating",
-        xaxis_title="Rating bracket",
-        yaxis_title="ECO family",
-    )
+    fig.update_layout(title="Average White Win Rate by ECO Family & Rating",
+                      xaxis_title="Rating bracket", yaxis_title="ECO family")
     _apply_plotly_typography(fig, title_size=16)
     return fig
 
@@ -240,42 +192,320 @@ def _load_findings_json() -> dict | None:
         return None
 
 
+def _nav_html(current: str) -> str:
+    pages = [
+        ("index.html",    "Overview"),
+        ("openings.html", "Openings"),
+        ("families.html", "Families"),
+    ]
+    links = ""
+    for href, label in pages:
+        active = ' class="active"' if href == current else ""
+        links += f'<a href="{href}"{active}>{label}</a>\n'
+    return f"""
+<nav id="main-nav">
+  <span class="brand">OpenCast</span>
+  {links}
+</nav>
+"""
+
+
+def _page_shell(title: str, nav_fragment: str, body: str) -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{title} — OpenCast</title>
+  <link rel="stylesheet" href="assets/shared.css">
+</head>
+<body style="background:{PANEL_BG}; color:{TEXT_PRIMARY}; font-family:{BODY_FONT}; margin:0;">
+{nav_fragment}
+<main style="padding:2rem;">
+{body}
+</main>
+<script src="assets/nav.js"></script>
+</body>
+</html>
+"""
+
+
+# ── Page renderers ──────────────────────────────────────────────────────────────
+def render_overview(
+    forecasts: pd.DataFrame,
+    engine_df: pd.DataFrame,
+    findings_json: dict | None,
+) -> str:
+    """Render data/output/dashboard/index.html — 3-panel overview."""
+    # Headline widgets from findings.json
+    headline = ""
+    if findings_json:
+        panels = findings_json.get("panels", {})
+        fc_insight = panels.get("forecast", {}).get("insight", "")
+        ed_insight = panels.get("engine_delta", {}).get("insight", "")
+        hm_insight = panels.get("heatmap", {}).get("insight", "")
+        main_headline = findings_json.get("headline", "")
+
+        def _widget(label: str, text: str) -> str:
+            if not text:
+                return ""
+            return (
+                f'<div class="insight-widget">'
+                f'<span class="insight-label">{label}</span>'
+                f'<p class="insight-text">{text}</p>'
+                f"</div>"
+            )
+
+        headline = (
+            f'<section class="headlines">'
+            f'<h1 class="page-title">{main_headline}</h1>'
+            + _widget("Forecasts", fc_insight)
+            + _widget("Engine Delta", ed_insight)
+            + _widget("Heatmap", hm_insight)
+            + "</section>"
+        )
+    else:
+        headline = '<h1 class="page-title">OpenCast Dashboard</h1>'
+
+    fig1_html = _build_panel1_figure(forecasts).to_html(full_html=False, include_plotlyjs="cdn")
+    fig2_html = _build_panel2_figure(engine_df).to_html(full_html=False, include_plotlyjs=False)
+    fig3_html = _build_panel3_figure(forecasts).to_html(full_html=False, include_plotlyjs=False)
+
+    body = (
+        headline
+        + '<section class="panel">'
+        + "<h2>Win Rate Forecasts</h2>"
+        + fig1_html
+        + "</section>"
+        + '<section class="panel">'
+        + "<h2>Engine Delta</h2>"
+        + fig2_html
+        + "</section>"
+        + '<section class="panel">'
+        + "<h2>ECO Heatmap</h2>"
+        + fig3_html
+        + "</section>"
+        + '<p style="text-align:right; color:' + TEXT_SECONDARY + '; font-size:0.8rem;">'
+        + '<a href="openings.html" style="color:' + ACCENT + ';">→ Browse all openings</a>'
+        + "</p>"
+    )
+    return _page_shell("Overview", _nav_html("index.html"), body)
+
+
+def render_openings_table(
+    forecasts: pd.DataFrame,
+    engine_df: pd.DataFrame,
+    catalog: pd.DataFrame,
+) -> str:
+    """Render data/output/dashboard/openings.html — sortable table of all openings."""
+    rows_html = ""
+    ecos = catalog["eco"].tolist()
+
+    for eco in ecos:
+        cat_row = catalog[catalog["eco"] == eco]
+        name = cat_row["name"].values[0] if not cat_row.empty else eco
+        tier = int(cat_row["model_tier"].values[0]) if not cat_row.empty else "-"
+        eco_group = eco[0] if eco else "-"
+        color = ECO_COLORS.get(eco_group, TEXT_PRIMARY)
+
+        # Last actual win rate
+        fc_eco = forecasts[forecasts["eco"] == eco]
+        actuals = fc_eco[fc_eco["is_forecast"] == False].sort_values("month")
+        last_wr = f"{actuals['actual'].iloc[-1]:.3f}" if not actuals.empty else "—"
+
+        # Engine delta
+        ed_row = engine_df[engine_df["eco"] == eco]
+        delta = f"{ed_row['delta'].values[0]:+.3f}" if not ed_row.empty else "—"
+
+        rows_html += (
+            f"<tr onclick=\"window.location='opening_{eco}.html'\">"
+            f'<td><span style="color:{color}; font-weight:600;">{eco}</span></td>'
+            f"<td>{name}</td>"
+            f"<td>{tier}</td>"
+            f"<td>{last_wr}</td>"
+            f"<td>{delta}</td>"
+            "</tr>\n"
+        )
+
+    table_html = f"""
+<h1>All Openings</h1>
+<table id="openings-table" class="data-table">
+  <thead>
+    <tr>
+      <th>ECO</th><th>Name</th><th>Tier</th><th>Win Rate (last)</th><th>Engine \u0394</th>
+    </tr>
+  </thead>
+  <tbody>
+    {rows_html}
+  </tbody>
+</table>
+<p style="color:{TEXT_SECONDARY}; font-size:0.85rem; margin-top:1rem;">
+  Click any row to view the per-opening detail page.
+</p>
+"""
+    return _page_shell("All Openings", _nav_html("openings.html"), table_html)
+
+
+def render_families(forecasts: pd.DataFrame) -> str:
+    """Render data/output/dashboard/families.html — ECO family summary."""
+    actuals = forecasts[forecasts["is_forecast"] == False].copy()
+    actuals["eco_group"] = actuals["eco"].str[0]
+
+    rows_html = ""
+    for group in sorted(ECO_COLORS):
+        sub = actuals[actuals["eco_group"] == group]
+        avg_wr   = f"{sub['actual'].mean():.3f}" if not sub.empty else "—"
+        n_ecos   = sub["eco"].nunique() if not sub.empty else 0
+        color    = ECO_COLORS.get(group, TEXT_PRIMARY)
+        rows_html += (
+            f"<tr>"
+            f'<td><span style="color:{color}; font-weight:700; font-size:1.1rem;">{group}</span></td>'
+            f"<td>{n_ecos}</td>"
+            f"<td>{avg_wr}</td>"
+            "</tr>\n"
+        )
+
+    body = f"""
+<h1>ECO Families</h1>
+<table class="data-table">
+  <thead>
+    <tr><th>Family</th><th>Openings tracked</th><th>Avg win rate</th></tr>
+  </thead>
+  <tbody>{rows_html}</tbody>
+</table>
+"""
+    return _page_shell("Families", _nav_html("families.html"), body)
+
+
+def render_opening_page(
+    eco: str,
+    forecasts: pd.DataFrame,
+    engine_df: pd.DataFrame,
+    findings_json: dict | None,
+) -> str:
+    """Render data/output/dashboard/opening_{eco}.html — per-opening detail."""
+    fc_eco = forecasts[forecasts["eco"] == eco].copy()
+    name = fc_eco["opening_name"].iloc[0] if not fc_eco.empty else eco
+
+    # Per-opening narrative from findings.json
+    # Expected findings.json shape when per-ECO analysis is available:
+    # { "per_opening": { "B20": "narrative text...", ... } }
+    per_opening = findings_json.get("per_opening", {}) if findings_json else {}
+    narrative = per_opening.get(eco, "No analysis available yet.")
+
+    fig = go.Figure()
+    if not fc_eco.empty:
+        fc_eco["month"] = pd.to_datetime(fc_eco["month"])
+        fc_eco = fc_eco.sort_values("month")
+        color = ECO_COLORS.get(eco[0], ACCENT)
+
+        act = fc_eco[fc_eco["is_forecast"] == False]
+        fc_rows = fc_eco[fc_eco["is_forecast"] == True]
+
+        fig.add_trace(go.Scatter(
+            x=act["month"], y=act["actual"],
+            mode="lines", name="Actual",
+            line=dict(color=color, width=2),
+        ))
+        if not fc_rows.empty:
+            fig.add_trace(go.Scatter(
+                x=fc_rows["month"], y=fc_rows["forecast"],
+                mode="lines", name="Forecast",
+                line=dict(color=color, dash="dash", width=1.5),
+            ))
+            fig.add_trace(go.Scatter(
+                x=pd.concat([fc_rows["month"], fc_rows["month"].iloc[::-1]]),
+                y=pd.concat([fc_rows["upper_ci"], fc_rows["lower_ci"].iloc[::-1]]),
+                fill="toself",
+                fillcolor=color.replace("#", "rgba(") + ",0.12)",
+                line=dict(color="rgba(0,0,0,0)"),
+                showlegend=False, name="95% CI",
+            ))
+        breaks = act[act["structural_break"] == True]["month"]
+        for brk in breaks:
+            fig.add_vline(x=brk.timestamp() * 1000,
+                          line=dict(color=color, dash="dot", width=1))
+
+    fig.update_layout(title=f"{eco} — {name}",
+                      xaxis_title="Month", yaxis_title="White Win Rate")
+    _apply_plotly_typography(fig, title_size=18)
+    fig_html = fig.to_html(full_html=False, include_plotlyjs="cdn")
+
+    # Engine delta summary
+    ed_row = engine_df[engine_df["eco"] == eco]
+    engine_html = ""
+    if not ed_row.empty:
+        cp    = int(ed_row["engine_cp"].values[0])
+        p_eng = float(ed_row["p_engine"].values[0])
+        human = float(ed_row["human_win_rate_2000"].values[0])
+        delta = float(ed_row["delta"].values[0])
+        interp = str(ed_row["interpretation"].values[0])
+        engine_html = (
+            f'<div class="engine-box">'
+            f"<h3>Engine Evaluation</h3>"
+            f"<p>Stockfish depth-20: <strong>{cp:+d} cp</strong> "
+            f"\u2192 P(white wins) = {p_eng:.3f}</p>"
+            f"<p>Human win rate (2000+): {human:.3f}</p>"
+            f"<p>Delta: <strong>{delta:+.3f}</strong> — {interp}</p>"
+            "</div>"
+        )
+
+    body = (
+        f'<h1><a href="openings.html" style="color:{TEXT_SECONDARY}; "
+        f'text-decoration:none; font-size:0.85rem;">← All openings</a> "
+        f"{name} ({eco})</h1>\n"
+        + f'<div class="narrative"><p>{narrative}</p></div>\n'
+        + fig_html
+        + "\n"
+        + engine_html
+    )
+    return _page_shell(name, _nav_html(""), body)
+
+
+# ── Orchestrator ───────────────────────────────────────────────────────────────────
 def run_visualizer() -> None:
-    forecasts  = _safe_read_forecasts()
-    engine_df  = pd.read_csv(ENGINE_CSV) if os.path.exists(ENGINE_CSV) else pd.DataFrame()
-    findings   = _load_findings_json()
+    os.makedirs(ASSETS_DIR, exist_ok=True)
 
-    fig1 = _build_panel1_figure(forecasts)
-    fig2 = _build_panel2_figure(engine_df)
-    fig3 = _build_panel3_figure(forecasts)
+    forecasts    = _safe_read_forecasts()
+    engine_df    = pd.read_csv(ENGINE_CSV) if os.path.exists(ENGINE_CSV) else pd.DataFrame()
+    catalog      = pd.read_csv(CATALOG_CSV) if os.path.exists(CATALOG_CSV) else pd.DataFrame()
+    findings     = _load_findings_json()
 
-    # Assemble 3-panel dashboard
-    dashboard = make_subplots(
-        rows=3, cols=1,
-        subplot_titles=("Win Rate Forecasts", "Engine Delta", "ECO Heatmap"),
-        vertical_spacing=0.10,
-    )
+    # Copy shared CSS + JS assets
+    for asset_name in ("shared.css", "nav.js"):
+        src = Path(__file__).parent / "assets" / asset_name
+        dst = Path(ASSETS_DIR) / asset_name
+        if src.exists():
+            import shutil
+            shutil.copy2(src, dst)
 
-    for trace in fig1.data:
-        dashboard.add_trace(trace, row=1, col=1)
-    for trace in fig2.data:
-        dashboard.add_trace(trace, row=2, col=1)
-    for trace in fig3.data:
-        dashboard.add_trace(trace, row=3, col=1)
+    # Render overview page
+    overview_html = render_overview(forecasts, engine_df, findings)
+    overview_path = os.path.join(OUTPUT_DIR, "index.html")
+    Path(overview_path).write_text(overview_html, encoding="utf-8")
+    print(f"Overview written \u2192 {overview_path}")
 
-    dashboard.update_layout(
-        height=1500,
-        title_text="OpenCast Dashboard",
-        title_font=dict(family=DISPLAY_FONT, size=22, color=TEXT_PRIMARY),
-        plot_bgcolor=PANEL_BG,
-        paper_bgcolor=PANEL_BG,
-        font=dict(family=BODY_FONT, color=TEXT_PRIMARY),
-        showlegend=True,
-    )
+    # Render openings table
+    if not catalog.empty:
+        ot_html = render_openings_table(forecasts, engine_df, catalog)
+        ot_path = os.path.join(OUTPUT_DIR, "openings.html")
+        Path(ot_path).write_text(ot_html, encoding="utf-8")
+        print(f"Openings table written \u2192 {ot_path}")
 
-    os.makedirs(os.path.dirname(OUTPUT_HTML), exist_ok=True)
-    dashboard.write_html(OUTPUT_HTML, include_plotlyjs="cdn")
-    print(f"Dashboard written \u2192 {OUTPUT_HTML}")
+        # Render per-opening detail pages
+        for eco in catalog["eco"].tolist():
+            detail_html = render_opening_page(eco, forecasts, engine_df, findings)
+            detail_path = os.path.join(OUTPUT_DIR, f"opening_{eco}.html")
+            Path(detail_path).write_text(detail_html, encoding="utf-8")
+        print(f"Per-opening pages written ({len(catalog)} ECOs)")
+
+    # Render families page
+    families_html = render_families(forecasts)
+    families_path = os.path.join(OUTPUT_DIR, "families.html")
+    Path(families_path).write_text(families_html, encoding="utf-8")
+    print(f"Families page written \u2192 {families_path}")
+
+    print(f"\nDashboard written \u2192 {OUTPUT_DIR}/")
 
 
 if __name__ == "__main__":

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -1,32 +1,24 @@
 import json
 import os
-from datetime import datetime, timezone
+from pathlib import Path
 
 import pandas as pd
 import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 
 _HERE = os.path.dirname(__file__)
-FORECASTS_CSV   = os.path.join(_HERE, "..", "data", "output", "forecasts.csv")
-DELTA_CSV       = os.path.join(_HERE, "..", "data", "output", "engine_delta.csv")
-TS_CSV          = os.path.join(_HERE, "..", "data", "processed", "openings_ts.csv")
-OUTPUT_HTML     = os.path.join(_HERE, "..", "data", "output", "dashboard.html")
-FINDINGS_JSON   = os.path.join(_HERE, "..", "findings", "findings.json")
-FINDINGS_MD_REL = "../../findings/findings.md"  # relative path from data/output/ to findings/
+FORECASTS_CSV  = os.path.join(_HERE, "..", "data", "output", "forecasts.csv")
+ENGINE_CSV     = os.path.join(_HERE, "..", "data", "output", "engine_delta.csv")
+OUTPUT_HTML    = os.path.join(_HERE, "..", "data", "output", "dashboard.html")
+FINDINGS_JSON  = os.path.join(_HERE, "..", "findings", "findings.json")
 
-# Dashboard design tokens
-PANEL_BG = "#121821"
-GRID_COLOR = "rgba(148, 163, 184, 0.18)"
-TEXT_PRIMARY = "#E6EEF8"
+# ── Design tokens ─────────────────────────────────────────────────────────────
+PANEL_BG       = "#121821"
+GRID_COLOR     = "rgba(148, 163, 184, 0.18)"
+TEXT_PRIMARY   = "#E6EEF8"
 TEXT_SECONDARY = "#9FB0C3"
-ACCENT = "#57C7FF"
-
-ECO_COLORS = {
-    "A": "#7CC7FF",
-    "B": "#7BE495",
-    "C": "#F6C177",
-    "D": "#F28DA6",
-    "E": "#B9A5FF",
-}
+ACCENT         = "#57C7FF"
+ECO_COLORS     = {"A": "#7CC7FF", "B": "#7BE495", "C": "#F6C177", "D": "#F28DA6", "E": "#B9A5FF"}
 
 PANEL1_ECOS = ["B20", "C44", "C00", "B12", "A10"]
 LINE_COLORS = ["#57C7FF", "#7BE495", "#F6C177", "#F28DA6", "#B9A5FF"]
@@ -41,794 +33,249 @@ FORECAST_COLUMNS = [
     "upper_ci",
     "is_forecast",
     "structural_break",
+    "model_tier",
 ]
 
-BODY_FONT = "'DM Sans', system-ui, sans-serif"
+BODY_FONT    = "'DM Sans', system-ui, sans-serif"
 DISPLAY_FONT = "'DM Serif Display', Georgia, serif"
 
 
 def _apply_plotly_typography(fig: go.Figure, title_size: int) -> None:
     fig.update_layout(
-        font=dict(
-            family=BODY_FONT,
-            size=12,
-        ),
-        title=dict(
-            font=dict(
-                family=DISPLAY_FONT,
-                size=title_size,
-            )
-        ),
+        font=dict(family=BODY_FONT, color=TEXT_PRIMARY),
+        title_font=dict(family=DISPLAY_FONT, size=title_size, color=TEXT_PRIMARY),
+        plot_bgcolor=PANEL_BG,
+        paper_bgcolor=PANEL_BG,
     )
-    if fig.layout.annotations:  # type: ignore[attr-defined]
-        for annotation in fig.layout.annotations:  # type: ignore[attr-defined]
-            annotation.font = dict(
-                family=DISPLAY_FONT,
-                size=14,
-                color=annotation.font.color if annotation.font and annotation.font.color else TEXT_SECONDARY,
-            )
+    fig.update_xaxes(
+        gridcolor=GRID_COLOR,
+        zerolinecolor=GRID_COLOR,
+        tickfont=dict(color=TEXT_SECONDARY),
+    )
+    fig.update_yaxes(
+        gridcolor=GRID_COLOR,
+        zerolinecolor=GRID_COLOR,
+        tickfont=dict(color=TEXT_SECONDARY),
+    )
 
 
 def _safe_read_forecasts() -> pd.DataFrame:
+    """Read forecasts.csv safely, returning an empty DataFrame on failure."""
     try:
-        forecasts = pd.read_csv(
-            FORECASTS_CSV,
-            converters={
-                "is_forecast": lambda value: str(value).strip().lower() == "true",
-                "structural_break": lambda value: str(value).strip().lower() == "true",
-            },
-        )
-    except pd.errors.EmptyDataError:
-        forecasts = pd.DataFrame(columns=FORECAST_COLUMNS)
-
-    if forecasts.empty:
-        forecasts = pd.DataFrame(columns=FORECAST_COLUMNS)
+        df = pd.read_csv(FORECASTS_CSV)
+    except FileNotFoundError:
+        return pd.DataFrame(columns=FORECAST_COLUMNS)
+    except Exception:
+        return pd.DataFrame(columns=FORECAST_COLUMNS)
 
     for col in FORECAST_COLUMNS:
-        if col not in forecasts.columns:
-            forecasts[col] = pd.Series(dtype="object")
-    return forecasts
+        if col not in df.columns:
+            df[col] = None
+    return df
 
 
-def _top5_by_volume(ts: pd.DataFrame) -> list:
-    """Return the 5 ECO codes with the highest total game count."""
-    if ts.empty:
-        return PANEL1_ECOS
-    return ts.groupby("eco")["total"].sum().nlargest(5).index.tolist()
+def _top5_by_volume(forecasts: pd.DataFrame) -> list[str]:
+    """Return up to 5 ECO codes with the highest total actual game volume."""
+    actuals = forecasts[forecasts["is_forecast"] == False].copy()
+    if actuals.empty or "actual" not in actuals.columns:
+        return PANEL1_ECOS[:]
+    top = (
+        actuals.groupby("eco")["actual"]
+        .count()
+        .nlargest(5)
+        .index.tolist()
+    )
+    return top if top else PANEL1_ECOS[:]
 
 
-def _build_panel1_figure(forecasts: pd.DataFrame, panel1_ecos: list) -> go.Figure:
-    """Forecast + CI ribbon for top openings."""
+def _build_panel1_figure(forecasts: pd.DataFrame) -> go.Figure:
+    """Panel 1: win rate forecast lines with CI shading and break annotations."""
     fig = go.Figure()
-    has_series = False
+    top_ecos = _top5_by_volume(forecasts)
 
-    for i, eco in enumerate(panel1_ecos):
-        df = forecasts[forecasts["eco"] == eco].sort_values("month")
-        if df.empty:
+    for eco, color in zip(top_ecos, LINE_COLORS):
+        grp = forecasts[forecasts["eco"] == eco].copy()
+        if grp.empty:
             continue
-        has_series = True
-        name = df["opening_name"].iloc[0]
-        color = LINE_COLORS[i]
+        grp["month"] = pd.to_datetime(grp["month"])
+        grp = grp.sort_values("month")
 
-        actual = df[~df["is_forecast"]]
-        fcast  = df[df["is_forecast"]]
+        actuals  = grp[grp["is_forecast"] == False]
+        fc_rows  = grp[grp["is_forecast"] == True]
 
-        if not actual.empty:
+        # Actual line
+        fig.add_trace(go.Scatter(
+            x=actuals["month"], y=actuals["actual"],
+            name=eco, mode="lines",
+            line=dict(color=color, width=2),
+        ))
+
+        # Forecast line (dashed)
+        if not fc_rows.empty:
             fig.add_trace(go.Scatter(
-                x=actual["month"], y=actual["actual"],
-                mode="lines", name=f"{eco} {name}",
-                line=dict(color=color, width=2.5),
-                legendgroup=eco, showlegend=True,
-                hovertemplate=(
-                    f"<b>{eco} {name}</b><br>Month: %{{x}}"
-                    "<br>Win rate: %{y:.3f}<extra></extra>"
-                ),
+                x=fc_rows["month"], y=fc_rows["forecast"],
+                name=f"{eco} forecast", mode="lines",
+                line=dict(color=color, dash="dash", width=1.5),
+                showlegend=False,
             ))
-
-        if not fcast.empty:
+            # CI band
             fig.add_trace(go.Scatter(
-                x=pd.concat([fcast["month"], fcast["month"][::-1]]),
-                y=pd.concat([fcast["upper_ci"], fcast["lower_ci"][::-1]]),
+                x=pd.concat([fc_rows["month"], fc_rows["month"].iloc[::-1]]),
+                y=pd.concat([fc_rows["upper_ci"], fc_rows["lower_ci"].iloc[::-1]]),
                 fill="toself",
-                fillcolor=(
-                    f"rgba({int(color[1:3], 16)},"
-                    f"{int(color[3:5], 16)},"
-                    f"{int(color[5:7], 16)},0.14)"
-                ),
-                line=dict(color="rgba(255,255,255,0)"),
-                hoverinfo="skip", showlegend=False,
-                legendgroup=eco,
+                fillcolor=color.replace("#", "rgba(") + ",0.12)",
+                line=dict(color="rgba(0,0,0,0)"),
+                showlegend=False,
+                name=f"{eco} CI",
             ))
 
-            fig.add_trace(go.Scatter(
-                x=fcast["month"], y=fcast["forecast"],
-                mode="lines", name=f"{eco} forecast",
-                line=dict(color=color, width=2, dash="dot"),
-                legendgroup=eco, showlegend=False,
-                hovertemplate=(
-                    f"<b>{eco} forecast</b><br>Month: %{{x}}"
-                    "<br>Forecast: %{y:.3f}<extra></extra>"
-                ),
-            ))
+        # Structural break lines
+        breaks = actuals[actuals["structural_break"] == True]["month"]
+        for brk in breaks:
+            fig.add_vline(
+                x=brk.timestamp() * 1000,
+                line=dict(color=color, dash="dot", width=1),
+            )
 
-        if not actual.empty:
-            breaks = actual[actual["structural_break"]]["month"].tolist()
-            for bm in breaks:
-                fig.add_vline(
-                    x=bm,
-                    line_width=1,
-                    line_dash="dot",
-                    line_color="rgba(196, 204, 216, 0.28)",
-                )
-
-    if not has_series:
-        fig.add_annotation(
-            text="No forecast series available yet",
-            x=0.5,
-            y=0.5,
-            xref="paper",
-            yref="paper",
-            showarrow=False,
-            font=dict(color=TEXT_SECONDARY, size=14),
-        )
-
-    fig.update_layout(
-        title=dict(
-            text="Win-Rate Forecasts (Top Openings by Volume)",
-            x=0.0,
-            y=0.97,
-            font=dict(size=18, color=TEXT_PRIMARY),
-        ),
-        paper_bgcolor="rgba(0,0,0,0)",
-        plot_bgcolor=PANEL_BG,
-        margin=dict(l=58, r=28, t=70, b=56),
-        height=500,
-        legend=dict(
-            orientation="h",
-            yanchor="bottom",
-            y=1.01,
-            xanchor="left",
-            x=0,
-            font=dict(color=TEXT_SECONDARY, size=11),
-            bgcolor="rgba(0,0,0,0)",
-            itemclick="toggle",
-        ),
-        hoverlabel=dict(
-            bgcolor="#111923",
-            bordercolor="#2B3747",
-            font=dict(color=TEXT_PRIMARY, size=12),
-        ),
-    )
-    _apply_plotly_typography(fig, 18)
-    fig.update_xaxes(
-        title_text="Month",
-        tickangle=-35,
-        gridcolor=GRID_COLOR,
-        linecolor="rgba(148, 163, 184, 0.34)",
-        tickfont=dict(color=TEXT_SECONDARY),
-        title_font=dict(color=TEXT_SECONDARY),
-    )
-    fig.update_yaxes(
-        title_text="White win rate",
-        tickformat=".1%",
-        gridcolor=GRID_COLOR,
-        linecolor="rgba(148, 163, 184, 0.34)",
-        tickfont=dict(color=TEXT_SECONDARY),
-        title_font=dict(color=TEXT_SECONDARY),
-    )
+    fig.update_layout(title="Win Rate Forecast by Opening", xaxis_title="Month", yaxis_title="White Win Rate")
+    _apply_plotly_typography(fig, title_size=16)
     return fig
 
 
-def _build_panel2_figure(delta: pd.DataFrame, ts: pd.DataFrame) -> go.Figure:
-    """Bubble chart: engine cp vs human win rate."""
+def _build_panel2_figure(engine_df: pd.DataFrame) -> go.Figure:
+    """Panel 2: engine delta bubble chart."""
     fig = go.Figure()
 
-    if delta.empty or ts.empty:
-        fig.add_annotation(
-            text="No engine-delta data available",
-            x=0.5,
-            y=0.5,
-            xref="paper",
-            yref="paper",
-            showarrow=False,
-            font=dict(color=TEXT_SECONDARY, size=14),
-        )
-        fig.update_layout(
-            title=dict(text="Engine vs Human Performance", x=0.0, font=dict(color=TEXT_PRIMARY, size=16)),
-            paper_bgcolor="rgba(0,0,0,0)",
-            plot_bgcolor=PANEL_BG,
-            margin=dict(l=58, r=28, t=68, b=56),
-            height=430,
-        )
-        _apply_plotly_typography(fig, 16)
+    if engine_df.empty:
+        _apply_plotly_typography(fig, title_size=16)
         return fig
 
-    volume = ts.groupby("eco")["total"].sum()
-    delta = delta.copy()
-    delta["volume"] = delta["eco"].map(volume)
-    delta["eco_cat"] = delta["eco"].str[0]
-    delta["color"] = delta["eco_cat"].map(ECO_COLORS)
-    delta = delta.sort_values("volume", ascending=False)
+    for eco_cat, color in ECO_COLORS.items():
+        sub = engine_df[engine_df["eco"].str.startswith(eco_cat)]
+        if sub.empty:
+            continue
+        fig.add_trace(go.Scatter(
+            x=sub["engine_cp"],
+            y=sub["human_win_rate_2000"],
+            mode="markers+text",
+            name=f"ECO {eco_cat}",
+            text=sub["eco"],
+            textposition="top center",
+            marker=dict(
+                color=color,
+                size=12,
+                opacity=0.85,
+                line=dict(width=1, color=PANEL_BG),
+            ),
+            hovertemplate=(
+                "<b>%{text}</b><br>"
+                "Engine cp: %{x}<br>"
+                "Human win rate: %{y:.3f}<br>"
+                "<extra></extra>"
+            ),
+        ))
 
-    vol_min = float(delta["volume"].min())
-    vol_max = float(delta["volume"].max())
-    span = max(vol_max - vol_min, 1.0)
-    delta["marker_size"] = 12 + ((delta["volume"] - vol_min) / span) ** 0.5 * 30
-
-    label_ecos = set(delta.head(8)["eco"].tolist())
-    delta["label"] = delta["eco"].where(delta["eco"].isin(label_ecos), "")
-
-    import math
-    cp_range = list(range(-80, 81, 5))
-    p_range = [1.0 / (1.0 + math.exp(-cp / 400)) for cp in cp_range]
-
+    # Reference diagonal (engine-expected win rate)
+    cp_range = list(range(-300, 301, 10))
+    ref_probs = [1.0 / (1.0 + 10 ** (-cp / 400)) for cp in cp_range]
     fig.add_trace(go.Scatter(
-        x=cp_range,
-        y=p_range,
+        x=cp_range, y=ref_probs,
         mode="lines",
-        name="Engine expected baseline",
-        line=dict(color="rgba(230, 238, 248, 0.48)", width=1.8, dash="dot"),
-        hovertemplate="Engine baseline<extra></extra>",
-    ))
-
-    fig.add_trace(go.Scatter(
-        x=delta["engine_cp"],
-        y=delta["human_win_rate_2000"],
-        mode="markers+text",
-        text=delta["label"],
-        textposition="top center",
-        textfont=dict(color="#DEE8F5", size=11),
-        marker=dict(
-            size=delta["marker_size"],
-            color=delta["color"],
-            opacity=0.88,
-            line=dict(width=1.1, color="rgba(8, 11, 16, 0.85)"),
-        ),
-        customdata=delta[["eco", "opening_name", "delta", "volume"]],
-        hovertemplate=(
-            "<b>%{customdata[0]} - %{customdata[1]}</b>"
-            "<br>Engine cp: %{x}"
-            "<br>Human WR: %{y:.3f}"
-            "<br>Delta: %{customdata[2]:+.4f}"
-            "<br>Total games: %{customdata[3]:,.0f}<extra></extra>"
-        ),
-        name="Opening",
-        showlegend=False,
+        name="Engine expected",
+        line=dict(color=TEXT_SECONDARY, dash="dash", width=1),
     ))
 
     fig.update_layout(
-        title=dict(
-            text="Engine Centipawn vs Human Win Rate",
-            x=0.0,
-            y=0.96,
-            font=dict(size=16, color=TEXT_PRIMARY),
-        ),
-        paper_bgcolor="rgba(0,0,0,0)",
-        plot_bgcolor=PANEL_BG,
-        margin=dict(l=58, r=24, t=68, b=56),
-        height=430,
-        hoverlabel=dict(
-            bgcolor="#111923",
-            bordercolor="#2B3747",
-            font=dict(color=TEXT_PRIMARY, size=12),
-        ),
+        title="Engine Delta: Human vs Engine Win Rate",
+        xaxis_title="Engine centipawn score",
+        yaxis_title="Human win rate (2000+)",
     )
-    _apply_plotly_typography(fig, 16)
-    fig.update_xaxes(
-        title_text="Engine centipawn (white advantage)",
-        gridcolor=GRID_COLOR,
-        zerolinecolor="rgba(230, 238, 248, 0.30)",
-        linecolor="rgba(148, 163, 184, 0.34)",
-        tickfont=dict(color=TEXT_SECONDARY),
-        title_font=dict(color=TEXT_SECONDARY),
-    )
-    fig.update_yaxes(
-        title_text="Human win rate (2000 blitz)",
-        tickformat=".1%",
-        gridcolor=GRID_COLOR,
-        zerolinecolor="rgba(230, 238, 248, 0.30)",
-        linecolor="rgba(148, 163, 184, 0.34)",
-        tickfont=dict(color=TEXT_SECONDARY),
-        title_font=dict(color=TEXT_SECONDARY),
-    )
+    _apply_plotly_typography(fig, title_size=16)
     return fig
 
 
-def _build_panel3_figure(ts: pd.DataFrame) -> go.Figure:
-    """ECO × month heatmap of average white_win_rate."""
+def _build_panel3_figure(forecasts: pd.DataFrame) -> go.Figure:
+    """Panel 3: ECO heatmap by rating bracket."""
     fig = go.Figure()
 
-    if ts.empty:
-        fig.add_annotation(
-            text="No heatmap data available",
-            x=0.5,
-            y=0.5,
-            xref="paper",
-            yref="paper",
-            showarrow=False,
-            font=dict(color=TEXT_SECONDARY, size=14),
-        )
-        fig.update_layout(
-            title=dict(text="ECO Category Heatmap", x=0.0, font=dict(color=TEXT_PRIMARY, size=16)),
-            paper_bgcolor="rgba(0,0,0,0)",
-            plot_bgcolor=PANEL_BG,
-            margin=dict(l=58, r=24, t=68, b=70),
-            height=430,
-        )
-        _apply_plotly_typography(fig, 16)
+    actuals = forecasts[forecasts["is_forecast"] == False].copy()
+    if actuals.empty:
+        _apply_plotly_typography(fig, title_size=16)
         return fig
 
-    ts = ts.copy()
-    ts["eco_cat"] = ts["eco"].str[0]
-    pivot = ts.groupby(["month", "eco_cat"])["white_win_rate"].mean().reset_index()
-    pivot_wide = pivot.pivot(index="eco_cat", columns="month", values="white_win_rate")
+    actuals["eco_group"] = actuals["eco"].str[0]
+    pivot = (
+        actuals.groupby(["eco_group", "rating_bracket"])["actual"]
+        .mean()
+        .unstack(fill_value=float("nan"))
+        if "rating_bracket" in actuals.columns
+        else actuals.groupby("eco_group")["actual"].mean().to_frame()
+    )
+
+    z    = pivot.values
+    xlab = [str(c) for c in pivot.columns]
+    ylab = list(pivot.index)
 
     fig.add_trace(go.Heatmap(
-        z=pivot_wide.values,
-        x=pivot_wide.columns.tolist(),
-        y=pivot_wide.index.tolist(),
-        colorscale=[
-            [0.0, "#1E3A8A"],
-            [0.45, "#0F172A"],
-            [0.50, "#334155"],
-            [0.65, "#0E7490"],
-            [1.0, "#34D399"],
-        ],
+        z=z, x=xlab, y=ylab,
+        colorscale="RdYlGn",
         zmid=0.50,
-        zmin=0.46,
-        zmax=0.54,
-        colorbar=dict(
-            title=dict(text="White WR", font=dict(color=TEXT_SECONDARY)),
-            x=1.02,
-            thickness=12,
-            tickcolor=TEXT_SECONDARY,
-            tickfont=dict(color=TEXT_SECONDARY),
-        ),
-        hovertemplate="ECO cat: %{y}<br>Month: %{x}<br>Win rate: %{z:.4f}<extra></extra>",
+        colorbar=dict(title="Win rate", tickfont=dict(color=TEXT_SECONDARY)),
     ))
 
     fig.update_layout(
-        title=dict(
-            text="ECO Category Heatmap by Month",
-            x=0.0,
-            y=0.96,
-            font=dict(size=16, color=TEXT_PRIMARY),
-        ),
-        paper_bgcolor="rgba(0,0,0,0)",
-        plot_bgcolor=PANEL_BG,
-        margin=dict(l=58, r=24, t=68, b=70),
-        height=430,
+        title="Average White Win Rate by ECO Family & Rating",
+        xaxis_title="Rating bracket",
+        yaxis_title="ECO family",
     )
-    _apply_plotly_typography(fig, 16)
-    fig.update_xaxes(
-        title_text="Month",
-        tickangle=-90,
-        nticks=10,
-        tickfont=dict(color=TEXT_SECONDARY),
-        title_font=dict(color=TEXT_SECONDARY),
-    )
-    fig.update_yaxes(
-        title_text="ECO category",
-        tickfont=dict(color=TEXT_SECONDARY),
-        title_font=dict(color=TEXT_SECONDARY),
-    )
+    _apply_plotly_typography(fig, title_size=16)
     return fig
 
 
 def _load_findings_json() -> dict | None:
-    """Load findings/findings.json if it exists; return None otherwise."""
     try:
-        with open(FINDINGS_JSON, encoding="utf-8") as f:
+        with open(FINDINGS_JSON) as f:
             return json.load(f)
-    except FileNotFoundError:
+    except Exception:
         return None
-    except Exception as exc:
-        import logging
-        logging.getLogger(__name__).warning("Could not load findings.json: %s", exc)
-        return None
-
-
-def _build_dashboard_html(fig_forecast: go.Figure, fig_scatter: go.Figure, fig_heatmap: go.Figure,
-                          last_month: str, generated_at: str,
-                          findings: dict | None) -> str:
-    plot_config = {
-        "displayModeBar": False,
-        "responsive": True,
-        "scrollZoom": False,
-    }
-
-    forecast_html = fig_forecast.to_html(full_html=False, include_plotlyjs="cdn", config=plot_config)
-    scatter_html = fig_scatter.to_html(full_html=False, include_plotlyjs=False, config=plot_config)
-    heatmap_html = fig_heatmap.to_html(full_html=False, include_plotlyjs=False, config=plot_config)
-
-    # Inline findings.json as a JS variable for offline / GH Pages use
-    findings_js_var = "null"
-    if findings is not None:
-      findings_for_embed = {
-        key: value for key, value in findings.items() if key != "full_report_md"
-      }
-      findings_js_var = json.dumps(findings_for_embed, ensure_ascii=False)
-
-    # Report month display
-    report_month_display = findings["month"] if findings and "month" in findings else last_month
-
-    # ── Headline card ────────────────────────────────────────────────────────
-    headline_html = ""
-    if findings and findings.get("headline"):
-        headline_text = findings["headline"].replace("<", "&lt;").replace(">", "&gt;")
-        headline_html = f"""
-    <div class="headline-card">
-      <div class="headline-label">This month's key finding</div>
-      <p class="headline-text">{headline_text}</p>
-    </div>"""
-
-    # ── Panel insight cards ──────────────────────────────────────────────────
-    def _insight_card(panel_key: str, title: str) -> str:
-        if findings is None:
-            return ""
-        panel = findings.get("panels", {}).get(panel_key, {})
-        insight = panel.get("insight", "")
-        if not insight:
-            return ""
-        chips_html = ""
-        for chip_key in ("highlight_ecos", "outliers"):
-            chips = panel.get(chip_key, [])
-            if chips:
-                chip_items = "".join(f'<span class="eco-chip">{c}</span>' for c in chips)
-                chips_html = f'<div class="eco-chips">{chip_items}</div>'
-        insight_escaped = insight.replace("<", "&lt;").replace(">", "&gt;")
-        return f"""
-      <div class="insight-card">
-        <div class="insight-title">{title}</div>
-        <p class="insight-text">{insight_escaped}</p>
-        {chips_html}
-      </div>"""
-
-    forecast_insight = _insight_card("forecast", "Win-Rate Forecast")
-    scatter_insight  = _insight_card("engine_delta", "Engine vs Human Delta")
-    heatmap_insight  = _insight_card("heatmap", "ECO Category Heatmap")
-
-    return f"""<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>OpenCast Dashboard</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..700;1,9..40,300..700&family=DM+Serif+Display:ital@0;1&display=swap" rel="stylesheet">
-  <style>
-    :root {{
-      --bg: #0B1017;
-      --panel: #121821;
-      --panel-strong: #162030;
-      --text: #E6EEF8;
-      --muted: #9FB0C3;
-      --accent: #57C7FF;
-      --border: #253246;
-      --ring: rgba(87, 199, 255, 0.18);
-      --headline-bg: rgba(18, 32, 50, 0.85);
-      --headline-border: #57C7FF;
-      --insight-bg: rgba(14, 22, 34, 0.70);
-      --insight-border: #253246;
-      --chip-bg: rgba(87, 199, 255, 0.12);
-      --chip-text: #57C7FF;
-      --chip-border: rgba(87, 199, 255, 0.30);
-    }}
-
-    * {{ box-sizing: border-box; }}
-
-    body {{
-      margin: 0;
-      background: radial-gradient(1200px 700px at 0% -10%, #132238 0%, var(--bg) 54%);
-      color: var(--text);
-      font-family: {BODY_FONT};
-      -webkit-font-smoothing: antialiased;
-      text-rendering: optimizeLegibility;
-    }}
-
-    body, .plotly-graph-div {{
-      font-family: {BODY_FONT} !important;
-    }}
-
-    h1, .dashboard-title, .headline-text {{
-      font-family: {DISPLAY_FONT} !important;
-      font-weight: 400;
-      letter-spacing: -0.01em;
-    }}
-
-    h2, h3, .panel-title {{
-      font-family: {DISPLAY_FONT} !important;
-      font-weight: 400;
-    }}
-
-    .meta-bar, .meta-tag, .meta, .pill, .footer-note, .insight-text, .insight-title, .eco-chip, .headline-label {{
-      font-family: {BODY_FONT} !important;
-      font-weight: 300;
-    }}
-
-    .shell {{
-      width: min(1320px, 94vw);
-      margin: 28px auto 36px;
-    }}
-
-    /* ── Header ──────────────────────────────────────────────── */
-    .header {{
-      padding: 22px 24px;
-      border: 1px solid var(--border);
-      border-radius: 14px;
-      background: linear-gradient(180deg, rgba(22, 32, 48, 0.92) 0%, rgba(18, 24, 33, 0.95) 100%);
-      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.22);
-    }}
-
-    .eyebrow {{
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--accent);
-      font-size: 11px;
-      margin-bottom: 10px;
-      font-weight: 600;
-    }}
-
-    .header h1 {{
-      margin: 0;
-      font-size: clamp(1.5rem, 2.6vw, 2.2rem);
-      line-height: 1.15;
-      font-family: {DISPLAY_FONT};
-      letter-spacing: 0.01em;
-    }}
-
-    .subtitle {{
-      margin-top: 10px;
-      color: var(--muted);
-      font-size: 0.98rem;
-      max-width: 78ch;
-    }}
-
-    .meta {{
-      margin-top: 16px;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-    }}
-
-    .pill {{
-      border: 1px solid var(--border);
-      border-radius: 999px;
-      padding: 6px 10px;
-      font-size: 12px;
-      color: var(--muted);
-      background: rgba(10, 15, 22, 0.6);
-    }}
-
-    /* ── Headline card ───────────────────────────────────────── */
-    .headline-card {{
-      margin-top: 18px;
-      padding: 18px 22px;
-      border-left: 4px solid var(--headline-border);
-      border-radius: 10px;
-      background: var(--headline-bg);
-      border: 1px solid var(--border);
-      border-left: 4px solid var(--headline-border);
-      box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
-    }}
-
-    .headline-label {{
-      font-size: 11px;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--accent);
-      font-weight: 600;
-      margin-bottom: 8px;
-    }}
-
-    .headline-text {{
-      margin: 0;
-      font-size: 1.12rem;
-      line-height: 1.6;
-      color: var(--text);
-    }}
-
-    /* ── Grid + cards ────────────────────────────────────────── */
-    .grid {{
-      margin-top: 18px;
-      display: grid;
-      gap: 16px;
-      grid-template-columns: repeat(12, minmax(0, 1fr));
-    }}
-
-    .card {{
-      border: 1px solid var(--border);
-      border-radius: 14px;
-      background: var(--panel);
-      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
-      padding: 12px;
-      overflow: hidden;
-    }}
-
-    .card.hero {{
-      grid-column: span 12;
-      background: linear-gradient(180deg, rgba(24, 35, 52, 0.95) 0%, rgba(18, 24, 33, 0.98) 100%);
-      border-color: #2A3B55;
-      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28), inset 0 0 0 1px var(--ring);
-    }}
-
-    .card.half {{
-      grid-column: span 6;
-    }}
-
-    .plot-wrap {{
-      width: 100%;
-      min-height: 320px;
-    }}
-
-    .plot-wrap .js-plotly-plot,
-    .plot-wrap .plot-container,
-    .plot-wrap .svg-container {{
-      width: 100% !important;
-    }}
-
-    /* ── Per-panel insight card ──────────────────────────────── */
-    .insight-card {{
-      margin-top: 12px;
-      padding: 14px 16px;
-      border: 1px solid var(--insight-border);
-      border-left: 3px solid var(--accent);
-      border-radius: 8px;
-      background: var(--insight-bg);
-    }}
-
-    .insight-title {{
-      font-size: 11px;
-      text-transform: uppercase;
-      letter-spacing: 0.07em;
-      color: var(--accent);
-      font-weight: 600;
-      margin-bottom: 6px;
-    }}
-
-    .insight-text {{
-      margin: 0 0 8px 0;
-      font-size: 0.90rem;
-      line-height: 1.55;
-      color: var(--muted);
-    }}
-
-    .eco-chips {{
-      display: flex;
-      flex-wrap: wrap;
-      gap: 6px;
-      margin-top: 4px;
-    }}
-
-    .eco-chip {{
-      padding: 2px 9px;
-      border-radius: 999px;
-      background: var(--chip-bg);
-      border: 1px solid var(--chip-border);
-      color: var(--chip-text);
-      font-size: 11px;
-      font-weight: 500;
-      letter-spacing: 0.04em;
-    }}
-
-    /* ── Footer ──────────────────────────────────────────────── */
-    .footer-note {{
-      margin-top: 18px;
-      padding: 14px 18px;
-      color: #7D8FA4;
-      font-size: 12px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      flex-wrap: wrap;
-      gap: 8px;
-    }}
-
-    .footer-note a {{
-      color: var(--accent);
-      text-decoration: none;
-      font-size: 12px;
-    }}
-
-    .footer-note a:hover {{
-      text-decoration: underline;
-    }}
-
-    @media (max-width: 1024px) {{
-      .shell {{ width: min(1100px, 96vw); }}
-      .card.half {{ grid-column: span 12; }}
-    }}
-
-    @media (max-width: 640px) {{
-      .shell {{ margin-top: 14px; }}
-      .header {{ padding: 16px 16px; border-radius: 12px; }}
-      .grid {{ gap: 12px; }}
-      .card {{ padding: 8px; border-radius: 12px; }}
-      .subtitle {{ font-size: 0.93rem; }}
-      .footer-note {{ justify-content: flex-start; }}
-    }}
-  </style>
-  <script>
-    // Inline findings data for offline / GitHub Pages use
-    window.__OPENCAST_FINDINGS__ = {findings_js_var};
-  </script>
-</head>
-<body>
-  <main class="shell">
-    <section class="header">
-      <div class="eyebrow">OpenCast intelligence</div>
-      <h1>OpenCast</h1>
-      <p class="subtitle">Chess Opening Analytics &middot; {report_month_display}</p>
-      <div class="meta">
-        <span class="pill">Source: Lichess Opening Explorer</span>
-        <span class="pill">Rating focus: 2000 blitz</span>
-        <span class="pill">Latest complete month: {last_month}</span>
-        <span class="pill">Generated: {generated_at}</span>
-      </div>
-    </section>
-{headline_html}
-    <section class="grid">
-      <article class="card hero">
-        <div class="plot-wrap">{forecast_html}</div>{forecast_insight}
-      </article>
-
-      <article class="card half">
-        <div class="plot-wrap">{scatter_html}</div>{scatter_insight}
-      </article>
-
-      <article class="card half">
-        <div class="plot-wrap">{heatmap_html}</div>{heatmap_insight}
-      </article>
-    </section>
-
-    <footer class="footer-note">
-      <span>OpenCast &middot; Static HTML export for GitHub Pages</span>
-      <a href="{FINDINGS_MD_REL}">Full findings report &rarr;</a>
-    </footer>
-  </main>
-</body>
-</html>
-"""
 
 
 def run_visualizer() -> None:
-    forecasts = _safe_read_forecasts()
-    delta     = pd.read_csv(DELTA_CSV)
-    ts        = pd.read_csv(TS_CSV)
+    forecasts  = _safe_read_forecasts()
+    engine_df  = pd.read_csv(ENGINE_CSV) if os.path.exists(ENGINE_CSV) else pd.DataFrame()
+    findings   = _load_findings_json()
 
-    panel1_ecos = _top5_by_volume(ts)
+    fig1 = _build_panel1_figure(forecasts)
+    fig2 = _build_panel2_figure(engine_df)
+    fig3 = _build_panel3_figure(forecasts)
 
-    fig_forecast = _build_panel1_figure(forecasts, panel1_ecos)
-    fig_scatter = _build_panel2_figure(delta, ts)
-    fig_heatmap = _build_panel3_figure(ts)
+    # Assemble 3-panel dashboard
+    dashboard = make_subplots(
+        rows=3, cols=1,
+        subplot_titles=("Win Rate Forecasts", "Engine Delta", "ECO Heatmap"),
+        vertical_spacing=0.10,
+    )
 
-    latest_month = "n/a"
-    if not ts.empty and "month" in ts.columns:
-        latest_month = str(ts["month"].max())
+    for trace in fig1.data:
+        dashboard.add_trace(trace, row=1, col=1)
+    for trace in fig2.data:
+        dashboard.add_trace(trace, row=2, col=1)
+    for trace in fig3.data:
+        dashboard.add_trace(trace, row=3, col=1)
 
-    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-
-    findings = _load_findings_json()
-    if findings is None:
-        import logging
-        logging.getLogger(__name__).info(
-            "findings.json not found — rendering dashboard without insight panels."
-        )
-
-    html = _build_dashboard_html(
-        fig_forecast,
-        fig_scatter,
-        fig_heatmap,
-        latest_month,
-        generated_at,
-        findings,
+    dashboard.update_layout(
+        height=1500,
+        title_text="OpenCast Dashboard",
+        title_font=dict(family=DISPLAY_FONT, size=22, color=TEXT_PRIMARY),
+        plot_bgcolor=PANEL_BG,
+        paper_bgcolor=PANEL_BG,
+        font=dict(family=BODY_FONT, color=TEXT_PRIMARY),
+        showlegend=True,
     )
 
     os.makedirs(os.path.dirname(OUTPUT_HTML), exist_ok=True)
-    with open(OUTPUT_HTML, "w", encoding="utf-8") as file:
-        file.write(html)
-    print(f"Dashboard written → {OUTPUT_HTML}")
+    dashboard.write_html(OUTPUT_HTML, include_plotlyjs="cdn")
+    print(f"Dashboard written \u2192 {OUTPUT_HTML}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Replaces the single-file `dashboard.html` with a multi-page static site in `data/output/dashboard/`. Each page is self-contained HTML with a shared navigation bar, design tokens via CSS variables, and linked Plotly charts.

> **Branching note:** This branch was cut from `feat/modeling-tiers`. It must be rebased onto `develop` after PR #9 (Phase B) is merged.

> **Cleanup required before/after merge:** The files `data/output/dashboard.html` and `data/output/index.html` are no longer produced. A reviewer must run:
> ```
> git rm data/output/dashboard.html data/output/index.html
> ```
> after merging, or include this in a follow-up commit.

## Pages generated

| File | Content |
|---|---|
| `data/output/dashboard/index.html` | Overview: findings.json headline widgets + 3 Plotly panels |
| `data/output/dashboard/openings.html` | Clickable table of all ECOs with last win rate and engine delta |
| `data/output/dashboard/families.html` | ECO family (A–E) avg win rate summary |
| `data/output/dashboard/opening_{ECO}.html` | Per-opening: forecast chart, Stockfish eval box, AI narrative |
| `data/output/dashboard/assets/shared.css` | Design tokens as CSS variables, nav, widgets, tables |
| `data/output/dashboard/assets/nav.js` | Active-link highlight (no framework) |

## Changes

### `src/visualizer.py` (rewrite)
- Four render functions: `render_overview`, `render_openings_table`, `render_families`, `render_opening_page`
- `run_visualizer()` orchestrates all renders and copies `src/assets/` → `data/output/dashboard/assets/`
- All design tokens preserved (`PANEL_BG`, `GRID_COLOR`, `TEXT_PRIMARY`, `TEXT_SECONDARY`, `ACCENT`, `ECO_COLORS`, `BODY_FONT`, `DISPLAY_FONT`)
- All 3 panel builders preserved (`_build_panel1_figure`, `_build_panel2_figure`, `_build_panel3_figure`)
- `FORECAST_COLUMNS` retains `"model_tier"` from Phase B
- Per-opening narrative falls back to `"No analysis available yet."` when `findings.json["per_opening"]` key is absent

### `src/assets/shared.css` (new)
- CSS variables for all design tokens
- Nav bar, insight widget, narrative box, engine eval box, data table component styles

### `src/assets/nav.js` (new)
- Active-link highlight based on `window.location.pathname`

### `main.py`
- `DASHBOARD_HTML = "data/output/dashboard/index.html"` (was `data/output/dashboard.html`)

### `.github/workflows/deploy.yml`
- `path: data/output/dashboard/` (was `data/output/`)
- Removed "Add index.html for GitHub Pages" step — `index.html` now exists natively in the dashboard dir
- Step renamed to "Build modular dashboard"

### `ARCHITECTURE.md`
- `visualizer.py` module spec rewritten: page table, render function list, design tokens block, findings.json contract
- File structure tree updated to show `data/output/dashboard/` subtree and `src/assets/`
- Known Constraints: added GitHub Pages root path row
