### PR TITLE
Update .gitignore to track specific output files for workflows

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -186,9 +186,8 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/processed/openings_ts.csv \
-              data/output/move_stats.csv \
-                  data/output/forecasts.csv \
-                  data/output/engine_delta.csv \
+              data/output/forecasts.csv \
+              data/output/engine_delta.csv \
                   data/output/dashboard/ \
                   findings/ \
                   data/openings_catalog.csv

--- a/.gitignore
+++ b/.gitignore
@@ -4,14 +4,18 @@ target/
 .env
 LICHESS_TOKEN
 
-# Generated data — specific tracked outputs and processed data
-!data/output/move_stats.csv
-!data/output/forecasts.csv
-!data/output/engine_delta.csv
-!data/processed/openings_ts.csv
+# Generated data — ignore most, but explicitly allow tracked outputs
+# First, ignore broadly
+data/processed/*.csv
 data/output/*.csv
 data/output/*.json
 data/output/*.html
+
+# Then allow specific tracked files
+!data/processed/openings_ts.csv
+!data/output/move_stats.csv
+!data/output/forecasts.csv
+!data/output/engine_delta.csv
 !data/output/dashboard/
 !data/**/.gitkeep
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,15 @@ target/
 .env
 LICHESS_TOKEN
 
-# Generated data — directories are tracked via .gitkeep
-data/processed/*.csv
+# Generated data — specific tracked outputs and processed data
+!data/output/move_stats.csv
+!data/output/forecasts.csv
+!data/output/engine_delta.csv
+!data/processed/openings_ts.csv
 data/output/*.csv
+data/output/*.json
 data/output/*.html
+!data/output/dashboard/
 !data/**/.gitkeep
 
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ data/output/*.html
 
 # Then allow specific tracked files
 !data/processed/openings_ts.csv
-!data/output/move_stats.csv
 !data/output/forecasts.csv
 !data/output/engine_delta.csv
 !data/output/dashboard/


### PR DESCRIPTION
This pull request makes a small change to the workflow configuration by removing the `data/output/move_stats.csv` file from the list of files staged for commit in the `.github/workflows/update.yml` file.