### PR TITLE
Enhance live board resizing with layout observation

### DIFF
--- a/data/output/dashboard/assets/opening.js
+++ b/data/output/dashboard/assets/opening.js
@@ -142,6 +142,7 @@ function appendStatCard(parent, label, value, valueStyle) {
 
 function renderOpeningBoard(eco, openingLines) {
 	const boardSection = document.getElementById("opening-board-section");
+	const layoutEl = document.querySelector(".opening-board-layout");
 	const frameEl = document.querySelector(".opening-board-frame");
 	const boardEl = document.getElementById("opening-board");
 	const ranksEl = document.getElementById("opening-board-ranks");
@@ -271,14 +272,22 @@ function renderOpeningBoard(eco, openingLines) {
 		window.__opencastBoardResizeObserver = null;
 	}
 	let boardResizeRaf = null;
+	let previousLayoutWidth = 0;
 	window.__opencastBoardResizeObserver = new ResizeObserver(() => {
+		if (!layoutEl) return;
+		const layoutWidth = Math.round(layoutEl.getBoundingClientRect().width);
+		if (!Number.isFinite(layoutWidth) || layoutWidth <= 0 || layoutWidth === previousLayoutWidth) return;
+		previousLayoutWidth = layoutWidth;
 		if (boardResizeRaf !== null) cancelAnimationFrame(boardResizeRaf);
 		boardResizeRaf = requestAnimationFrame(() => {
 			boardResizeRaf = null;
 			forceBoardResize();
 		});
 	});
-	window.__opencastBoardResizeObserver.observe(frameEl);
+	if (layoutEl) {
+		previousLayoutWidth = Math.round(layoutEl.getBoundingClientRect().width);
+		window.__opencastBoardResizeObserver.observe(layoutEl);
+	}
 }
 
 function renderHistoricalSummary(data) {

--- a/src/assets/opening.js
+++ b/src/assets/opening.js
@@ -142,6 +142,7 @@ function appendStatCard(parent, label, value, valueStyle) {
 
 function renderOpeningBoard(eco, openingLines) {
 	const boardSection = document.getElementById("opening-board-section");
+	const layoutEl = document.querySelector(".opening-board-layout");
 	const frameEl = document.querySelector(".opening-board-frame");
 	const boardEl = document.getElementById("opening-board");
 	const ranksEl = document.getElementById("opening-board-ranks");
@@ -271,14 +272,22 @@ function renderOpeningBoard(eco, openingLines) {
 		window.__opencastBoardResizeObserver = null;
 	}
 	let boardResizeRaf = null;
+	let previousLayoutWidth = 0;
 	window.__opencastBoardResizeObserver = new ResizeObserver(() => {
+		if (!layoutEl) return;
+		const layoutWidth = Math.round(layoutEl.getBoundingClientRect().width);
+		if (!Number.isFinite(layoutWidth) || layoutWidth <= 0 || layoutWidth === previousLayoutWidth) return;
+		previousLayoutWidth = layoutWidth;
 		if (boardResizeRaf !== null) cancelAnimationFrame(boardResizeRaf);
 		boardResizeRaf = requestAnimationFrame(() => {
 			boardResizeRaf = null;
 			forceBoardResize();
 		});
 	});
-	window.__opencastBoardResizeObserver.observe(frameEl);
+	if (layoutEl) {
+		previousLayoutWidth = Math.round(layoutEl.getBoundingClientRect().width);
+		window.__opencastBoardResizeObserver.observe(layoutEl);
+	}
 }
 
 function renderHistoricalSummary(data) {


### PR DESCRIPTION
Added observation of the layout element to the ResizeObserver for improved responsiveness. This change ensures that the board resizes correctly when the layout width changes, enhancing the user experience without requiring a page reload.